### PR TITLE
Run bouncer QA/Prod in hop-prod VPC

### DIFF
--- a/bouncer/env-prod.yml
+++ b/bouncer/env-prod.yml
@@ -33,6 +33,6 @@ OptionSettings:
     DefaultProcess: default
     Protocol: HTTPS
   aws:autoscaling:launchconfiguration:
-    SecurityGroups: sg-b3d625d4
+    SecurityGroups: sg-fdf9c19a
     IamInstanceProfile: aws-elasticbeanstalk-ec2-role
     EC2KeyName: ops

--- a/bouncer/env-prod.yml
+++ b/bouncer/env-prod.yml
@@ -16,9 +16,9 @@ OptionSettings:
   aws:elasticbeanstalk:healthreporting:system:
     SystemType: enhanced
   aws:ec2:vpc:
-    Subnets: subnet-8edc08d6,subnet-4904822d
-    VPCId: vpc-84e819e0
-    ELBSubnets: subnet-8fdc08d7,subnet-4804822c
+    Subnets: subnet-0f19e456,subnet-ee2c418b
+    VPCId: vpc-bc4d91d9
+    ELBSubnets: subnet-9bf985c3,subnet-3b21015f
     ELBScheme: public
     AssociatePublicIpAddress: true
   aws:autoscaling:updatepolicy:rollingupdate:

--- a/bouncer/env-qa.yml
+++ b/bouncer/env-qa.yml
@@ -33,6 +33,6 @@ OptionSettings:
     DefaultProcess: default
     Protocol: HTTPS
   aws:autoscaling:launchconfiguration:
-    SecurityGroups: sg-b3d625d4
+    SecurityGroups: sg-fdf9c19a
     IamInstanceProfile: aws-elasticbeanstalk-ec2-role
     EC2KeyName: ops

--- a/bouncer/env-qa.yml
+++ b/bouncer/env-qa.yml
@@ -16,9 +16,9 @@ OptionSettings:
   aws:elasticbeanstalk:healthreporting:system:
     SystemType: enhanced
   aws:ec2:vpc:
-    Subnets: subnet-8edc08d6,subnet-4904822d
-    VPCId: vpc-84e819e0
-    ELBSubnets: subnet-8fdc08d7,subnet-4804822c
+    Subnets: subnet-0f19e456,subnet-ee2c418b
+    VPCId: vpc-bc4d91d9
+    ELBSubnets: subnet-9bf985c3,subnet-3b21015f
     ELBScheme: public
     AssociatePublicIpAddress: true
   aws:autoscaling:updatepolicy:rollingupdate:


### PR DESCRIPTION
This depends on:
* [X] hypothesis/playbook#131 merged and being run
* [x] hypothesis/playbook#132 merged and being run

This changes the VPC id, subnet ids, and security group for the EC2 launch configuration in order to run bouncer QA/Prod in our own `hop-prod` VPC. For testing reasons, we used to run it in the VPC that is managed by Skyliner.