### PR TITLE
Add ability to promote deployments

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,8 @@
 
 // The list of applications which can be deployed.
 def deployApplications = ['bouncer', 'via'].join('\n')
+// The list of deployment types.
+def deployTypes = ['promote', 'exact-version', 'sync-env'].join('\n')
 // The list of environments. It is assumed that each application has one of each
 // of these environments.
 def deployEnvironments = ['qa', 'prod'].join('\n')
@@ -13,12 +15,17 @@ pipeline {
         choice(name: 'APP',
                choices: deployApplications,
                description: 'Choose the application to deploy.')
+        choice(name: 'TYPE',
+               choices: deployTypes,
+               description: 'Choose the deployment type. ' +
+                            '`promote` promotes the last successful QA deployment to prod. ' +
+                            '`exact-version` pushes a specific docker tag. ' +
+                            '`sync-env` synchronizes the environment definition.',
+                defaultValue: 'promote')
         string(name: 'APP_DOCKER_VERSION',
                description: 'The tag of the application docker image to ' +
-                            'deploy. If you do not supply a tag, the ' +
-                            'environment configuration will be synchronised ' +
-                            'instead. (This can only happen if the ' +
-                            'environment has already been created.)',
+                            'deploy. This is required if the selected ' +
+                            'deployment type is `exact-version`.',
                defaultValue: '')
         choice(name: 'ENV',
                choices: deployEnvironments,

--- a/bin/eb-env-current-version
+++ b/bin/eb-env-current-version
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+
+"""
+Return the currently deployed docker tag in the given app and environment.
+"""
+
+import argparse
+import re
+import sys
+
+import boto3
+
+parser = argparse.ArgumentParser()
+parser.add_argument('app')
+parser.add_argument('env')
+
+
+def main():
+    args = parser.parse_args()
+
+    client = boto3.client('elasticbeanstalk')
+
+    app_version = fetch_application_version(client, args)
+    docker_tag = parse_docker_tag(app_version, args)
+    print(docker_tag)
+
+
+def fetch_application_version(client, args):
+    """Fetch current application version for specified environment."""
+    env_name = '{}-{}'.format(args.app, args.env)
+    result = client.describe_environments(ApplicationName=args.app,
+                                          EnvironmentNames=[env_name])
+    envs = result['Environments']
+
+    if len(envs) == 0:
+        abort('no matching environment found')
+
+    if len(envs) > 1:
+        abort('multiple environments found, but this tool only works '
+              'if environment names are unique within an application')
+
+    return envs[0]['VersionLabel']
+
+
+def parse_docker_tag(app_version, args):
+    # We want to parse out the docker tag that we put into the application
+    # version. An example application version is: bouncer-20170602T132529Z-20170602-g35940db
+    # The last part of this is the docker tag that is deployed: 20170602-g35940db
+    exp = '^%s-[0-9]{8}T[0-9]{6}Z-(.+)$' % re.escape(args.app)
+    result = re.search(exp, app_version)
+    if result is None:
+        abort('Found an incorrect application version "%s"' % app_version)
+
+    docker_tag = result.group(1)
+    return docker_tag
+
+
+def abort(message):
+    print('Error: {}'.format(message), file=sys.stderr)
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/jenkins
+++ b/bin/jenkins
@@ -2,8 +2,14 @@
 
 # The name of the Elastic Beanstalk application to manage
 : ${APP:=}
+# The type of the deployment.
+# * `promote` fetches the latest successful QA deployment and
+#   promotes it to prod.
+# * `exact-version` deploys a specific version to the environmen.
+# * `sync-env` synchronizes the Elastic Beanstalk environment.
+: ${TYPE:=}
 # If deploying an application version, the docker tag of the version to create
-# and release. If not specified, we run an environment settings sync.
+# and release.
 : ${APP_DOCKER_VERSION:=}
 # The environment on which to operate (typically "qa" or "prod"). Note that the
 # name of the environment in Elastic Beanstalk will be prefixed with the name of
@@ -28,10 +34,24 @@ if [ -z "$ENV" ]; then
     abort "cannot proceed unless \$ENV is specified"
 fi
 
-if [ -n "$APP_DOCKER_VERSION" ]; then
-    eb-deploy "$APP" "$ENV" "$APP_DOCKER_VERSION"
+if [ "$TYPE" = "exact-version" ]; then
+  if [ -z "$APP_DOCKER_VERSION" ]; then
+    abort "cannot proceed with exact-version deploy unless \$APP_DOCKER_VERSION is specified"
+  fi
+
+  eb-deploy "$APP" "$ENV" "$APP_DOCKER_VERSION"
+elif [ "$TYPE" = "promote" ]; then
+  if [ "$ENV" != "prod" ]; then
+    abort "can only promote a deployment to production"
+  fi
+
+  docker_tag=$(eb-env-current-version "$APP" qa)
+  eb-deploy "$APP" "$ENV" "$docker_tag"
+
+elif [ "$TYPE" = "sync-env" ]; then
+  eb-env-sync "$APP" "$ENV"
 else
-    eb-env-sync "$APP" "$ENV"
+  abort "Don't know how to handle deployment type \"$TYPE\""
 fi
 
 eb-env-wait "$APP" "$ENV"


### PR DESCRIPTION
At the same time this introduces a new parameter called `TYPE` which
defines the type of deployment. This is so we can support the easiest
path for being able to promote QA deployments to prod.

This parameter can have three values:

* `promote` fetches the latest successful QA deployment and
  re-deploys it to QA, or promotes it to prod.
* `exact-version` deploys a specific version to the environmen.
* `sync-env` synchronizes the Elastic Beanstalk environment.