### PR TITLE
Add more information to build name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,6 +54,11 @@ pipeline {
     stages {
         stage('setup') {
             steps {
+                script {
+                    def label = "#${currentBuild.number} ${params.APP} " +
+                                "${params.ENV} ${params.TYPE}"
+                    currentBuild.displayName = label
+                }
                 postSlack('start', params)
             }
         }


### PR DESCRIPTION
This will make it a bit easier to distinguish different builds in the
list.

Some examples would be:
* `#58 bouncer qa sync-env`
* `#59 bouncer qa exact-version`
* `#60 bouncer prod promote`

Instead of the old build name which is just the number (`#58`).