### PR TITLE
Split eb-release out of eb-deploy

### DIFF
--- a/bin/eb-deploy
+++ b/bin/eb-deploy
@@ -1,14 +1,17 @@
 #!/bin/sh
 
 usage () {
-    echo "Usage: $(basename "$0") <APP> <ENV> <APP_DOCKER_TAG>"
+    echo "Usage: $(basename "$0") <APP> <ENV> <VERSION_LABEL>"
     echo
-    echo "Deploy an application at a specified Docker image tag to the named"
+    echo "Deploy an application at a specified version to the named"
     echo "environment."
+    echo
+    echo "N.B. The application version is assumed to have already been created"
+    echo "in Elastic Beanstalk using, for example, the eb-release script."
     echo
     echo "  APP              the name of the application, e.g. 'bouncer'"
     echo "  ENV              the environment: typically 'qa' or 'prod'"
-    echo "  APP_DOCKER_TAG   the tag of the Docker image to release"
+    echo "  VERSION_LABEL    the application version"
 }
 
 abort () {
@@ -32,53 +35,7 @@ PATH="$(dirname "$0"):${PATH}"
 
 APP=$1
 ENV=$2
-APP_DOCKER_TAG=$3
-
-if [ ! -f "${APP}/Dockerrun.aws.json" ]; then
-    abort "there must be a Dockerrun.aws.json in the app directory (${APP}/)"
-fi
-
-# Deploying the application to Elastic Beanstalk has several steps:
-#
-# 1. Upload a tweaked version of the application's Dockerrun.aws.json template
-#    to the ElasticBeanstalk S3 bucket.
-# 2. Create an application version using the uploaded template. This creates the
-#    application automatically if it needs to.
-# 3. Create or update the named environment with the uploaded version of the
-#    application.
-
-
-status "preparing application source bundle"
-
-# Use JQ to append ":<APP_DOCKER_TAG>" to the image name in the template JSON
-# file.
-SRCBUNDLE=$(mktemp)
-jq ".Image.Name += \":${APP_DOCKER_TAG}\"" <"${APP}/Dockerrun.aws.json" >"$SRCBUNDLE"
-
-# And clean up when we're done...
-trap 'rm "$SRCBUNDLE"' EXIT
-
-
-status "fetching storage location"
-
-EB_BUCKET=$(aws elasticbeanstalk create-storage-location --query S3Bucket --output text)
-
-
-status "uploading application version to S3"
-
-VERSION_LABEL="${APP}-$(date -u +"%Y%m%dT%H%M%SZ")-${APP_DOCKER_TAG}"
-aws s3 cp "$SRCBUNDLE" "s3://${EB_BUCKET}/${APP}/${VERSION_LABEL}.json"
-
-
-status "creating application version in EB"
-
-aws elasticbeanstalk create-application-version \
-    --application-name "$APP" \
-    --version-label "$VERSION_LABEL" \
-    --source-bundle "S3Bucket=${EB_BUCKET},S3Key=${APP}/${VERSION_LABEL}.json" \
-    --process \
-    --auto-create-application
-
+VERSION_LABEL=$3
 
 status "deploying application"
 

--- a/bin/eb-env-version
+++ b/bin/eb-env-version
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
 """
-Return the currently deployed docker tag in the given app and environment.
+Return the currently deployed application version label for the given
+application and environment.
 """
 
 import argparse
@@ -20,9 +21,7 @@ def main():
 
     client = boto3.client('elasticbeanstalk')
 
-    app_version = fetch_application_version(client, args)
-    docker_tag = parse_docker_tag(app_version, args)
-    print(docker_tag)
+    print(fetch_application_version(client, args))
 
 
 def fetch_application_version(client, args):
@@ -40,19 +39,6 @@ def fetch_application_version(client, args):
               'if environment names are unique within an application')
 
     return envs[0]['VersionLabel']
-
-
-def parse_docker_tag(app_version, args):
-    # We want to parse out the docker tag that we put into the application
-    # version. An example application version is: bouncer-20170602T132529Z-20170602-g35940db
-    # The last part of this is the docker tag that is deployed: 20170602-g35940db
-    exp = '^%s-[0-9]{8}T[0-9]{6}Z-(.+)$' % re.escape(args.app)
-    result = re.search(exp, app_version)
-    if result is None:
-        abort('Found an incorrect application version "%s"' % app_version)
-
-    docker_tag = result.group(1)
-    return docker_tag
 
 
 def abort(message):

--- a/bin/eb-release
+++ b/bin/eb-release
@@ -1,0 +1,85 @@
+#!/bin/sh
+
+usage () {
+    echo "Usage: $(basename "$0") <APP> <APP_DOCKER_TAG>"
+    echo
+    echo "Create an application version for the named application using a"
+    echo "specified Docker image tag."
+    echo
+    echo "Returns the app version created in Elastic Beanstalk."
+    echo
+    echo "  APP              the name of the application, e.g. 'bouncer'"
+    echo "  APP_DOCKER_TAG   the tag of the Docker image to release"
+}
+
+abort () {
+    echo "Error:" "$@" >&2
+    echo "Aborting!" >&2
+    exit 1
+}
+
+status () {
+    echo "--->" "$@" >&2
+}
+
+if [ "$#" -ne 2 ]; then
+    usage >&2
+    exit 1
+fi
+
+set -eu
+
+PATH="$(dirname "$0"):${PATH}"
+
+APP=$1
+APP_DOCKER_TAG=$2
+
+if [ ! -f "${APP}/Dockerrun.aws.json" ]; then
+    abort "there must be a Dockerrun.aws.json in the app directory (${APP}/)"
+fi
+
+# Deploying an application to Elastic Beanstalk has several steps:
+#
+# 1. Upload a tweaked version of the application's Dockerrun.aws.json template
+#    to the ElasticBeanstalk S3 bucket.
+# 2. Create an application version using the uploaded template. This creates the
+#    application automatically if it needs to.
+# 3. Create or update the named environment with the uploaded version of the
+#    application.
+#
+# This script does steps 1 and 2. The `eb-deploy` script is responsible for step
+# 3.
+
+
+status "preparing application source bundle"
+
+# Use JQ to append ":<APP_DOCKER_TAG>" to the image name in the template JSON
+# file.
+SRCBUNDLE=$(mktemp)
+jq ".Image.Name += \":${APP_DOCKER_TAG}\"" <"${APP}/Dockerrun.aws.json" >"$SRCBUNDLE"
+
+# And clean up when we're done...
+trap 'rm "$SRCBUNDLE"' EXIT
+
+
+status "fetching storage location"
+
+EB_BUCKET=$(aws elasticbeanstalk create-storage-location --query S3Bucket --output text)
+
+
+status "uploading application version to S3"
+
+VERSION_LABEL="${APP}-$(date -u +"%Y%m%dT%H%M%SZ")-${APP_DOCKER_TAG}"
+aws s3 cp --quiet "$SRCBUNDLE" "s3://${EB_BUCKET}/${APP}/${VERSION_LABEL}.json"
+
+
+status "creating application version in EB"
+
+aws elasticbeanstalk create-application-version \
+    --application-name "$APP" \
+    --version-label "$VERSION_LABEL" \
+    --source-bundle "S3Bucket=${EB_BUCKET},S3Key=${APP}/${VERSION_LABEL}.json" \
+    --process \
+    --auto-create-application \
+    --query 'ApplicationVersion.VersionLabel' \
+    --output text

--- a/bin/jenkins
+++ b/bin/jenkins
@@ -39,14 +39,16 @@ if [ "$TYPE" = "exact-version" ]; then
     abort "cannot proceed with exact-version deploy unless \$APP_DOCKER_VERSION is specified"
   fi
 
-  eb-deploy "$APP" "$ENV" "$APP_DOCKER_VERSION"
+  version_label=$(eb-release "$APP" "$APP_DOCKER_VERSION")
+  eb-deploy "$APP" "$ENV" "$version_label"
+
 elif [ "$TYPE" = "promote" ]; then
   if [ "$ENV" != "prod" ]; then
     abort "can only promote a deployment to production"
   fi
 
-  docker_tag=$(eb-env-current-version "$APP" qa)
-  eb-deploy "$APP" "$ENV" "$docker_tag"
+  version_label=$(eb-env-version "$APP" qa)
+  eb-deploy "$APP" "$ENV" "$version_label"
 
 elif [ "$TYPE" = "sync-env" ]; then
   eb-env-sync "$APP" "$ENV"


### PR DESCRIPTION
Deploying an application to an EB environment consists of two main steps:

1. Creating an "application version" in Elastic Beanstalk corresponding to a particular Docker image tag.
2. Triggering an environment update in which the environment is configured to use the application version created in the previous step.

This PR moves the code associate with part 1 out of `eb-deploy` and into a separate script, `eb-release`, which returns the created version label on STDOUT.

This simplifies implementation of the "promote" deployment type and will simplify implementation of a "redeploy" deployment type, as these can then deal in the version labels used by Elastic Beanstalk natively, rather than constantly having to translate back and forth between Docker tag and version label.