### PR TITLE
Replace 'promote' deploy type with 'redeploy'

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,21 +3,21 @@
 // The list of applications which can be deployed.
 def deployApplications = ['bouncer', 'h', 'h-periodic', 'metabase', 'via'].join('\n')
 // The list of deployment types.
-def deployTypes = ['promote', 'exact-version', 'sync-env'].join('\n')
+def deployTypes = ['deploy', 'redeploy', 'sync-env'].join('\n')
 // The list of environments. It is assumed that each application has one of each
 // of these environments.
 def deployEnvironments = ['qa', 'prod'].join('\n')
 
 def postSlack(state, params) {
     def messages = [
-        'start': ['promote': "Starting to promote ${params.APP} to ${params.ENV}",
-                  'exact-version': "Starting to deploy ${params.APP} ${params.APP_DOCKER_VERSION} to ${params.ENV}",
+        'start': ['deploy': "Starting to deploy ${params.APP} ${params.APP_DOCKER_VERSION} to ${params.ENV}",
+                  'redeploy': "Starting re-deployment of ${params.APP} in ${params.ENV}",
                   'sync-env': "Starting to synchronize the ${params.APP}-${params.ENV} environment"],
-        'success': ['promote': "Successfully promoted ${params.APP} to ${params.ENV}",
-                  'exact-version': "Successfully deployed ${params.APP} ${params.APP_DOCKER_VERSION} to ${params.ENV}",
-                  'sync-env': "Successfully synchronized the ${params.APP}-${params.ENV} environment"],
-        'error': ['promote': "Failed to promote ${params.APP} to ${params.ENV}",
-                  'exact-version': "Failed to deploy ${params.APP} ${params.APP_DOCKER_VERSION} to ${params.ENV}",
+        'success': ['deploy': "Successfully deployed ${params.APP} ${params.APP_DOCKER_VERSION} to ${params.ENV}",
+                    'redeploy': "Successfully re-deployed ${params.APP} in ${params.ENV}",
+                    'sync-env': "Successfully synchronized the ${params.APP}-${params.ENV} environment"],
+        'error': ['deploy': "Failed to deploy ${params.APP} ${params.APP_DOCKER_VERSION} to ${params.ENV}",
+                  'redeploy': "Failed to re-deploy ${params.APP} in ${params.ENV}",
                   'sync-env': "Failed to synchronize the ${params.APP}-${params.ENV} environment"]
     ]
     def colors = ['start': 'good', 'success': 'good', 'error': 'danger']
@@ -34,13 +34,13 @@ pipeline {
         choice(name: 'TYPE',
                choices: deployTypes,
                description: 'Choose the deployment type. ' +
-                            '`promote` promotes the last successful QA deployment to prod. ' +
-                            '`exact-version` pushes a specific docker tag. ' +
+                            '`deploy` releases and deploys a specific application version. ' +
+                            '`redeploy` triggers a redeployment of the currently-deployed version. ' +
                             '`sync-env` synchronizes the environment definition.')
         string(name: 'APP_DOCKER_VERSION',
                description: 'The tag of the application docker image to ' +
                             'deploy. This is required if the selected ' +
-                            'deployment type is `exact-version`.',
+                            'deployment type is `deploy`.',
                defaultValue: '')
         choice(name: 'ENV',
                choices: deployEnvironments,

--- a/bin/jenkins
+++ b/bin/jenkins
@@ -3,9 +3,8 @@
 # The name of the Elastic Beanstalk application to manage
 : ${APP:=}
 # The type of the deployment.
-# * `promote` fetches the latest successful QA deployment and
-#   promotes it to prod.
-# * `exact-version` deploys a specific version to the environmen.
+# * `deploy` releases and deploys a specific app version to the environment.
+# * `redeploy` triggers a redeployment of the currently-deployed version.
 # * `sync-env` synchronizes the Elastic Beanstalk environment.
 : ${TYPE:=}
 # If deploying an application version, the docker tag of the version to create
@@ -34,20 +33,20 @@ if [ -z "$ENV" ]; then
     abort "cannot proceed unless \$ENV is specified"
 fi
 
-if [ "$TYPE" = "exact-version" ]; then
+if [ "$TYPE" = "deploy" ]; then
   if [ -z "$APP_DOCKER_VERSION" ]; then
-    abort "cannot proceed with exact-version deploy unless \$APP_DOCKER_VERSION is specified"
+    abort "cannot proceed with deploy unless \$APP_DOCKER_VERSION is specified"
   fi
 
   version_label=$(eb-release "$APP" "$APP_DOCKER_VERSION")
   eb-deploy "$APP" "$ENV" "$version_label"
 
-elif [ "$TYPE" = "promote" ]; then
-  if [ "$ENV" != "prod" ]; then
-    abort "can only promote a deployment to production"
+elif [ "$TYPE" = "redeploy" ]; then
+  if [ -n "$APP_DOCKER_VERSION" ]; then
+    abort "do not specify \$APP_DOCKER_VERSION for a redeploy"
   fi
 
-  version_label=$(eb-env-version "$APP" qa)
+  version_label=$(eb-env-version "$APP" "$ENV")
   eb-deploy "$APP" "$ENV" "$version_label"
 
 elif [ "$TYPE" = "sync-env" ]; then


### PR DESCRIPTION
The way that the deployment pipelines for individual applications now work means that a separate "promote" deployment type isn't that useful.

What is very useful, however, is a deployment type that simply triggers a redeployment of the currently deployed version to an environment, thus cycling the infrastructure for that environment.

This commit:

- Removes the 'promote' deployment type
- Adds a 'redeploy' deployment type
- Renames the 'exact-version' deployment type to simply 'deploy' so it's clearer what is going on in Jenkins logs.