### PR TITLE
Update platform version when syncing environments

### DIFF
--- a/bin/eb-env-sync
+++ b/bin/eb-env-sync
@@ -58,9 +58,18 @@ eb-manifest-settings <"$MANIFEST" >"$OPTION_SETTINGS_FILE"
 trap 'rm "$OPTION_SETTINGS_FILE"' EXIT
 
 
+# We also need to parse out the ElasticBeanstalk platform ARN and
+# and pass it to the `--platform-arn` parameter.
+
+status "parsing platform ARN"
+
+EB_PLATFORM_ARN=$(eb-manifest-platform <"$MANIFEST")
+
+
 status "updating environment"
 
 aws elasticbeanstalk update-environment \
     --application-name "$APP" \
     --environment-name "${APP}-${ENV}" \
+    --platform-arn "$EB_PLATFORM_ARN" \
     --option-settings file://"$OPTION_SETTINGS_FILE"

--- a/bin/eb-manifest-platform
+++ b/bin/eb-manifest-platform
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+"""
+Extract the platform ARN from an Elastic Beanstalk environment
+manifest provided on STDIN and print it to STDOUT.
+"""
+
+import sys
+import yaml
+
+
+def main():
+    manifest = yaml.load(sys.stdin)
+
+    platform = manifest.get('Platform', {})
+    platform_arn = platform.get('PlatformArn', None)
+
+    if not platform_arn:
+        print('Error: Could not find a platform ARN', file=sys.stderr)
+        sys.exit(1)
+
+    print(platform_arn)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Previously we only updated the environment options, but not the
platform. This parses the platform and passes it to the
`aws elasticbeanstalk update-environment` command.