### PR TITLE
Ability to run remote commands

### DIFF
--- a/bin/eb-release
+++ b/bin/eb-release
@@ -53,13 +53,26 @@ fi
 
 status "preparing application source bundle"
 
+SRCBUNDLEDIR=$(mktemp -d)
+
 # Use JQ to append ":<APP_DOCKER_TAG>" to the image name in the template JSON
 # file.
-SRCBUNDLE=$(mktemp)
-jq ".Image.Name += \":${APP_DOCKER_TAG}\"" <"${APP}/Dockerrun.aws.json" >"$SRCBUNDLE"
+jq ".Image.Name += \":${APP_DOCKER_TAG}\"" <"${APP}/Dockerrun.aws.json" >"$SRCBUNDLEDIR/Dockerrun.aws.json"
+
+# Copy additional configuration
+EBEXTENSIONS="${SRCBUNDLEDIR}/.ebextensions/"
+if [ -d "common/ebextensions" ]; then
+  mkdir -p "$EBEXTENSIONS"
+  cp common/ebextensions/*.config "$EBEXTENSIONS"
+fi
+# Allow application to override common ebextensions
+if [ -d "${APP}/ebextensions" ]; then
+  mkdir -p "$EBEXTENSIONS"
+  cp ${APP}/ebextensions/*.config "$EBEXTENSIONS"
+fi
 
 # And clean up when we're done...
-trap 'rm "$SRCBUNDLE"' EXIT
+trap 'rm -r "$SRCBUNDLEDIR"' EXIT
 
 
 status "fetching storage location"
@@ -70,7 +83,13 @@ EB_BUCKET=$(aws elasticbeanstalk create-storage-location --query S3Bucket --outp
 status "uploading application version to S3"
 
 VERSION_LABEL="${APP}-$(date -u +"%Y%m%dT%H%M%SZ")-${APP_DOCKER_TAG}"
-aws s3 cp --quiet "$SRCBUNDLE" "s3://${EB_BUCKET}/${APP}/${VERSION_LABEL}.json"
+SRCBUNDLE="${SRCBUNDLEDIR}/bundle.zip"
+
+pushd "$SRCBUNDLEDIR"
+zip -r "$SRCBUNDLE" .
+popd
+
+aws s3 cp --quiet "$SRCBUNDLE" "s3://${EB_BUCKET}/${APP}/${VERSION_LABEL}.zip"
 
 
 status "creating application version in EB"
@@ -78,7 +97,7 @@ status "creating application version in EB"
 aws elasticbeanstalk create-application-version \
     --application-name "$APP" \
     --version-label "$VERSION_LABEL" \
-    --source-bundle "S3Bucket=${EB_BUCKET},S3Key=${APP}/${VERSION_LABEL}.json" \
+    --source-bundle "S3Bucket=${EB_BUCKET},S3Key=${APP}/${VERSION_LABEL}.zip" \
     --process \
     --auto-create-application \
     --query 'ApplicationVersion.VersionLabel' \

--- a/bin/eb-task-run
+++ b/bin/eb-task-run
@@ -1,0 +1,105 @@
+#!/bin/sh
+
+set -eu
+
+usage () {
+    echo "Usage: $(basename "$0") <APP> <ENV> <TIMEOUT> <COMMAND>"
+    echo
+    echo "Run a command inside the Docker container of a running Elastic Beanstalk"
+    echo "instance and tail the output."
+    echo
+    echo "  APP            the name of the application, e.g. 'bouncer'"
+    echo "  ENV            the environment: typically 'qa' or 'prod'"
+    echo "  TIMEOUT        the command timeout in seconds"
+    echo "  COMMAND        the command to run, e.g. 'hypothesis user admin myuser'"
+    echo
+    echo "Note that the selected instance will be protected from a scale-in event"
+    echo "for the duration of the command."
+}
+
+abort () {
+    echo "Error:" "$@" >&2
+    echo "Aborting!" >&2
+    exit 1
+}
+
+status () {
+    echo "--->" "$@" >&2
+}
+
+if [ "$#" -ne 4 ]; then
+    usage >&2
+    exit 1
+fi
+
+PATH="$(dirname "$0"):${PATH}"
+
+APP=$1
+ENV=$2
+TIMEOUT=$3
+COMMAND=$4
+
+
+if ! eb-env-exists "$APP" "$ENV"; then
+    abort "$ENV environment doesn't exist for $APP"
+fi
+
+
+# Select a running instance for the given application and environment.
+
+status "selecting instance"
+
+INSTANCE_ID=$(aws ec2 describe-instances \
+                  --filters "Name=tag:elasticbeanstalk:environment-name,Values=${APP}-${ENV}" \
+                            "Name=instance-state-name,Values=running" \
+                  --query "Reservations[0].Instances[0].InstanceId" \
+                  --output text)
+
+if [ "$INSTANCE_ID" = "None" ]; then
+  abort "Could not find a running instance for $APP and $ENV"
+fi
+
+
+# Protect instance from a scale-in event
+
+status "protecting instance from a scale-in event"
+
+remove_instance_protection() {
+  asg_name=$1
+  instance_id=$2
+
+  status "removing instance protection"
+  echo aws autoscaling set-instance-protection \
+      --auto-scaling-group-name "$asg_name" \
+      --instance-ids "$instance_id" \
+      --no-protected-from-scale-in
+}
+
+ASG_NAME=$(aws elasticbeanstalk describe-environment-resources \
+               --environment-name "${APP}-${ENV}" \
+               --query "EnvironmentResources.AutoScalingGroups[0].Name" \
+               --output text)
+
+aws autoscaling set-instance-protection \
+    --auto-scaling-group-name "$ASG_NAME" \
+    --instance-ids "$INSTANCE_ID" \
+    --protected-from-scale-in
+
+trap "remove_instance_protection '$ASG_NAME' '$INSTANCE_ID'" EXIT
+
+
+status "initiating command"
+
+COMMAND_ID=$(aws ssm send-command \
+                 --instance-ids "$INSTANCE_ID" \
+                 --document-name "AWS-RunShellScript" \
+                 --parameters "{
+                     \"executionTimeout\": [\"$TIMEOUT\"],
+                     \"commands\": [\"/usr/local/sbin/run-docker-task $COMMAND\"]
+                 }" \
+                 --query 'Command.CommandId' \
+                 --output-s3-bucket-name 'elasticbeanstalk-run-command-output' \
+                 --output text)
+
+status "running command"
+eb-task-wait "$COMMAND_ID" "$INSTANCE_ID"

--- a/bin/eb-task-wait
+++ b/bin/eb-task-wait
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+
+"""
+Wait for an SSM task execution to finish.
+
+This script periodically polls the Systems Manager API to determine whether
+the command execution has finished or not. At the end of the execution it
+will display the command output.
+
+The script exits with a status code according to the Run-Command exit status.
+"""
+
+import argparse
+import datetime
+import sys
+import time
+
+import boto3
+
+IN_PROGRESS_STATUSES = ['Pending', 'In Progress', 'Delayed']
+
+parser = argparse.ArgumentParser()
+parser.add_argument('command_id')
+parser.add_argument('instance_id')
+
+
+def main():
+    args = parser.parse_args()
+    loop(args)
+
+
+def loop(args):
+    client = boto3.client('ssm')
+
+    while True:
+        resp = client.get_command_invocation(CommandId=args.command_id,
+                                             InstanceId=args.instance_id)
+        status = resp.get('Status')
+        if is_in_progress(status):
+            print('.', end='', flush=True)
+            time.sleep(5)
+        elif is_success(status):
+            print_outputs(resp)
+            sys.exit(0)
+        else:
+            print_outputs(stdout, stderr)
+            abort('Command finished with errors.')
+
+
+def is_in_progress(status):
+    return status in ['Pending', 'InProgress', 'Delayed']
+
+
+def is_success(status):
+    return status == 'Success'
+
+
+def print_outputs(response):
+    status('stdout output:')
+    print(response.get('StandardOutputContent'))
+    print('')
+    status('stderr output:')
+    print(response.get('StandardErrorContent'))
+    print('')
+    status('full logs available on S3:')
+    status('  stdout: %s' % response.get('StandardOutputUrl'))
+    status('  stderr: %s' % response.get('StandardErrorUrl'))
+
+
+def status(message):
+    print('---> %s' % message)
+
+
+def abort(message):
+    print('Error: {}'.format(message), file=sys.stderr)
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/common/ebextensions/tasks.config
+++ b/common/ebextensions/tasks.config
@@ -1,0 +1,3 @@
+packages:
+  rpm:
+    amazon-ssm-agent: https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_386/amazon-ssm-agent.rpm

--- a/common/ebextensions/tasks.config
+++ b/common/ebextensions/tasks.config
@@ -1,3 +1,39 @@
 packages:
   rpm:
     amazon-ssm-agent: https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_386/amazon-ssm-agent.rpm
+files:
+  "/usr/local/sbin/run-docker-task":
+    mode: 000770
+    owner: root
+    group: root
+    content: |
+      #!/bin/sh
+
+      set -eu
+
+      usage () {
+          echo "Usage: $(basename "$0") <COMMAND>"
+          echo
+          echo "Run a command inside the first running Docker container."
+          echo
+          echo "  COMMAND        the command to run, e.g. 'hypothesis user admin myuser'"
+          echo
+      }
+
+      if [ "$#" -lt 1 ]; then
+          usage >&2
+          exit 1
+      fi
+
+
+      # Fetch id of first running container
+      CONTAINER_ID=$(docker ps --filter "status=running"  --format "{{.ID}}" | head -n1)
+
+      if [ -z "$CONTAINER_ID" ]; then
+          echo "Error: Cannot find a running container" >&2
+          exit 1
+      fi
+
+
+      # Execute command
+      docker exec "$CONTAINER_ID" "$@"


### PR DESCRIPTION
These commits install the Amazon SSM agent on the Elastic Beanstalk instances and add an `eb-run-task` script which can be used to execute remote commands.

The infrastructure changes that are needed (new policy to IAM instance role, S3 bucket) are done in hypothesis/playbook#142