### PR TITLE
Add Jenkins pipeline for running tasks on h instances

### DIFF
--- a/h/Jenkinsfile-tasks
+++ b/h/Jenkinsfile-tasks
@@ -1,0 +1,89 @@
+#!groovy
+
+def environments = ['qa', 'prod'].join('\n')
+
+def tasks = [
+    'db current revision (timeout 10m)': [cmd: 'migrate current', timeout: '600'],
+    'db upgrade to head (timeout 10m)': [cmd: 'migrate upgrade head', timeout: '600', confirm: true],
+    'db upgrade to next (timeout 10m)': [cmd: 'migrate upgrade +1', timeout: '600', confirm: true],
+    'db downgrade to previous (timeout 10m)': [cmd: 'migrate downgrade -1', timeout: '600', confirm: true],
+    'search reindex (timeout 2h)': [cmd: 'search reindex', timeout: '7200', confirm: true]
+]
+
+def taskChoices = tasks.keySet().join('\n')
+
+def postSlack(state, env, task) {
+    messages = [
+        'start': "Starting task \"${task}\" on h-${env}",
+        'error': "Failed to run task \"${task}\" on h-${env}",
+        'success': "Successfully ran task \"${task}\" on h-${env}"
+    ]
+    def colors = ['start': 'good', 'success': 'good', 'error': 'danger']
+
+    slackSend color: colors[state], message: messages[state]
+}
+
+pipeline {
+    agent { dockerfile true }
+
+    parameters {
+        choice(name: 'ENV',
+               choices: environments,
+               description: 'Choose on which environment to run the given task.')
+        choice(name: 'TASK',
+               choices: taskChoices,
+               description: 'Choose which task to run on the given environment.')
+        string(name: 'TASK_TIMEOUT',
+               description: 'Each task defines its own default timeout, this can ' +
+                            'be overridden here. The value is in seconds.',
+               defaultValue: 'task-default')
+    }
+
+    environment {
+        AWS_DEFAULT_REGION = 'us-west-1'
+    }
+
+    stages {
+        stage('setup') {
+            steps {
+                script {
+                    currentBuild.displayName = "#${currentBuild.number} - " +
+                                               "${params.ENV} ${params.TASK}"
+                }
+            }
+        }
+
+        stage('main') {
+            steps {
+                withCredentials([[$class: 'AmazonWebServicesCredentialsBinding',
+                                  credentialsId: 'aws-elasticbeanstalk-jenkins']]) {
+
+                    script {
+                        def task = tasks[params.TASK]
+                        if (task == null) {
+                            error("Cannot find task with name \"${params.TASK}\"")
+                        }
+
+                        def cmd = task['cmd']
+                        def timeout = task['timeout']
+
+                        if (params.TASK_TIMEOUT != 'task-default') {
+                            timeout = params.TASK_TIMEOUT
+                        }
+
+                        if (task['confirm'] == true) {
+                            input(message: "This task might be dangerous. Do you wish to continue?")
+                        }
+                        postSlack('start', params.ENV, params.TASK)
+                        sh "bin/eb-task-run h ${params.ENV} ${timeout} \"hypothesis ${cmd}\""
+                    }
+                }
+            }
+        }
+    }
+
+    post {
+        failure { postSlack('error', params.ENV, params.TASK) }
+        success { postSlack('success', params.ENV, params.TASK) }
+    }
+}


### PR DESCRIPTION
This is the Jenkins portion of the work that started in #11.

We can then configure a Jenkins Pipeline project that uses this script
which has a couple of common tasks pre-configured that we can run
against either the qa or prod environment.

For testing purposes, I already created the Jenkins project which is using this branch and is available at https://jenkins.hypothes.is/job/h-tasks/
Note: Until a new h version is deployed to production the tasks will only work in qa, as prod instances don't have the SSM agent installed yet.