### PR TITLE
Add lms app qa and prod envs

### DIFF
--- a/lms/Dockerrun.aws.json
+++ b/lms/Dockerrun.aws.json
@@ -1,0 +1,11 @@
+{
+  "AWSEBDockerrunVersion": "1",
+  "Image": {
+    "Name": "hypothesis/lms"
+  },
+  "Ports": [
+    {
+      "ContainerPort": "8001"
+    }
+  ]
+}

--- a/lms/env-prod.yml
+++ b/lms/env-prod.yml
@@ -1,0 +1,39 @@
+AWSConfigurationTemplateVersion: 1.1.0.0
+Platform:
+  PlatformArn: arn:aws:elasticbeanstalk:us-west-1::platform/Docker running on 64bit Amazon Linux/2.7.2
+EnvironmentTier:
+  Type: Standard
+  Name: WebServer
+OptionSettings:
+  aws:elasticbeanstalk:command:
+    DeploymentPolicy: Immutable
+  aws:elasticbeanstalk:environment:
+    EnvironmentType: LoadBalanced
+    LoadBalancerType: application
+    ServiceRole: aws-elasticbeanstalk-service-role
+  aws:elasticbeanstalk:environment:process:default:
+    HealthCheckPath: /_status
+  aws:elasticbeanstalk:healthreporting:system:
+    SystemType: enhanced
+  aws:ec2:vpc:
+    Subnets: subnet-0f19e456,subnet-ee2c418b
+    VPCId: vpc-bc4d91d9
+    ELBSubnets: subnet-9bf985c3,subnet-3b21015f
+    ELBScheme: public
+    AssociatePublicIpAddress: true
+  aws:autoscaling:updatepolicy:rollingupdate:
+    RollingUpdateType: Immutable
+    RollingUpdateEnabled: true
+  aws:elbv2:listener:default:
+    ListenerEnabled: false
+  aws:elbv2:listener:443:
+    ListenerEnabled: true
+    SSLPolicy: ELBSecurityPolicy-TLS-1-2-2017-01
+    SSLCertificateArns: arn:aws:acm:us-west-1:964867326460:certificate/ef36b626-66e0-495e-813c-71a3b883f692
+    DefaultProcess: default
+    Protocol: HTTPS
+  aws:autoscaling:launchconfiguration:
+    SecurityGroups: sg-fdf9c19a,sg-86756ee0
+    IamInstanceProfile: aws-elasticbeanstalk-ec2-role
+    InstanceType: t2.nano
+    EC2KeyName: ops

--- a/lms/env-qa.yml
+++ b/lms/env-qa.yml
@@ -1,0 +1,39 @@
+AWSConfigurationTemplateVersion: 1.1.0.0
+Platform:
+  PlatformArn: arn:aws:elasticbeanstalk:us-west-1::platform/Docker running on 64bit Amazon Linux/2.7.2
+EnvironmentTier:
+  Type: Standard
+  Name: WebServer
+OptionSettings:
+  aws:elasticbeanstalk:command:
+    DeploymentPolicy: Immutable
+  aws:elasticbeanstalk:environment:
+    EnvironmentType: LoadBalanced
+    LoadBalancerType: application
+    ServiceRole: aws-elasticbeanstalk-service-role
+  aws:elasticbeanstalk:environment:process:default:
+    HealthCheckPath: /_status
+  aws:elasticbeanstalk:healthreporting:system:
+    SystemType: enhanced
+  aws:ec2:vpc:
+    Subnets: subnet-0f19e456,subnet-ee2c418b
+    VPCId: vpc-bc4d91d9
+    ELBSubnets: subnet-9bf985c3,subnet-3b21015f
+    ELBScheme: public
+    AssociatePublicIpAddress: true
+  aws:autoscaling:updatepolicy:rollingupdate:
+    RollingUpdateType: Immutable
+    RollingUpdateEnabled: true
+  aws:elbv2:listener:default:
+    ListenerEnabled: false
+  aws:elbv2:listener:443:
+    ListenerEnabled: true
+    SSLPolicy: ELBSecurityPolicy-TLS-1-2-2017-01
+    SSLCertificateArns: arn:aws:acm:us-west-1:964867326460:certificate/ef36b626-66e0-495e-813c-71a3b883f692
+    DefaultProcess: default
+    Protocol: HTTPS
+  aws:autoscaling:launchconfiguration:
+    SecurityGroups: sg-fdf9c19a,sg-86756ee0
+    IamInstanceProfile: aws-elasticbeanstalk-ec2-role
+    InstanceType: t2.nano
+    EC2KeyName: ops


### PR DESCRIPTION
These files are copied from the corresponding files in the lti dir. I changed "lti" to "lms", and changed the ID of the lti app security group to that of the lms app security group. That's all I changed.

This is the same as what Christof did for the lti app, in two separate commits, here <https://github.com/hypothesis/deployment/commit/e19bfacf1aef96a6fbe1e6ac49c48fb1e8ad05fd> and here <https://github.com/hypothesis/deployment/commit/d681f3255554ba691b824c0d1d6f3b1dc553dc7c>.

I'm not sure that merging this will actually do anything on Elastic Beanstalk yet because lms hasn't been added to this line yet:

https://github.com/hypothesis/deployment/blob/cb3c28a24f72240cb24d904b18557aa68116fdca/Jenkinsfile#L4

But Christof edited that file in a separate commit when he did the lti app so I'd like to do that separately for the lms app too.