### PR TITLE
Add second target channel for Jenkins messages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,13 @@ def postSlack(state, params) {
     ]
     def colors = ['start': 'good', 'success': 'good', 'error': 'danger']
     slackSend color: colors[state], message: messages[state][params.TYPE]
+
+    // allow a single additional channel per repo as a target for the message
+    def additionalChannels = ['lms': '#feat-canvas']
+    def additionalChannel = additionalChannels.find(it.key == params.APP)?.value
+    if (additionalChannel) {
+        slackSend channel: "${additionalChannel}", color: colors[state], message: messages[state][params.TYPE]
+    }
 }
 
 pipeline {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,9 +25,8 @@ def postSlack(state, params) {
 
     // allow a single additional channel per repo as a target for the message
     def additionalChannels = ['lms': '#feat-canvas']
-    def additionalChannel = additionalChannels.find(it.key == params.APP)?.value
-    if (additionalChannel) {
-        slackSend channel: "${additionalChannel}", color: colors[state], message: messages[state][params.TYPE]
+    if (additionalChannels.containsKey(params.APP)) {
+        slackSend channel: "${additionalChannels[params.APP]}", color: colors[state], message: messages[state][params.TYPE]
     }
 }
 

--- a/lms/Jenkinsfile-tasks
+++ b/lms/Jenkinsfile-tasks
@@ -19,12 +19,7 @@ def postSlack(state, env, task) {
     ]
     def colors = ['start': 'good', 'success': 'good', 'error': 'danger']
 
-    // keep sending messages to the default channel
     slackSend color: colors[state], message: messages[state]
-    // additionally, send messages to #feat-canvas by
-    // overriding the default channel using the `channel` parameter
-    // from: https://jenkins.io/doc/pipeline/steps/slack/
-    slackSend channel: "#feat-canvas", color: colors[state], message: messages[state]
 }
 
 pipeline {

--- a/lms/Jenkinsfile-tasks
+++ b/lms/Jenkinsfile-tasks
@@ -19,7 +19,12 @@ def postSlack(state, env, task) {
     ]
     def colors = ['start': 'good', 'success': 'good', 'error': 'danger']
 
+    // keep sending messages to the default channel
     slackSend color: colors[state], message: messages[state]
+    // additionally, send messages to #feat-canvas by
+    // overriding the default channel using the `channel` parameter
+    // from: https://jenkins.io/doc/pipeline/steps/slack/
+    slackSend channel: "#feat-canvas", color: colors[state], message: messages[state]
 }
 
 pipeline {


### PR DESCRIPTION
While we have Atomic Jolt engaged with us working on the LTI app, it would be helpful to have Jenkins builds report into the channel to which they have access (#feat-canvas).

This change adds a second call to `slackSend` with an additional parameter, `channel`, set to the name of the channel. In theory, this should send all Jenkins messages for the `lti` repo to both #eng-general and #feat-canvas.