### PR TITLE
Set resource lifecycles of apps

### DIFF
--- a/bin/eb-env-sync
+++ b/bin/eb-env-sync
@@ -65,6 +65,11 @@ status "parsing platform ARN"
 
 EB_PLATFORM_ARN=$(eb-manifest-platform <"$MANIFEST")
 
+status "updating application resource lifecycle settings"
+
+aws elasticbeanstalk update-application-resource-lifecycle \
+    --application-name "$APP" \
+    --resource-lifecycle-config file://resource-lifecycle.json
 
 status "updating environment"
 

--- a/resource-lifecycle.json
+++ b/resource-lifecycle.json
@@ -1,0 +1,9 @@
+{
+  "VersionLifecycleConfig": {
+    "MaxCountRule": {
+      "Enabled": true,
+      "MaxCount": 500,
+      "DeleteSourceFromS3": true
+    }
+  }
+}


### PR DESCRIPTION
Set the resource lifecycles of our apps in Elastic Beanstalk when doing
a sync-env.

We hit an Elastic Beanstalk limit that caused deploying h to qa to stop
working:

https://jenkins.hypothes.is/job/deployment/572/console

"An error occurred (TooManyApplicationVersionsException) when calling the
CreateApplicationVersion operation: You cannot have more than 500
Application Versions. Either remove some Application Versions or request
a limit increase."

It turns out that every time we deploy a new version of an app to
Elastic Beanstalk it's keeping all those old versions, and once it has
500 of them it refuses to let us add any more.

The fix is to configure the "application version lifecycle settings" for
each app in Elastic Beanstalk, and tell it to keep only the most recent
500 versions of each app and delete the oldest versions in order to make way
for new versions when we try to deploy a new version.

See:

https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/applications-lifecycle.html

and:

https://docs.aws.amazon.com/cli/latest/reference/elasticbeanstalk/update-application-resource-lifecycle.html

This commit adds an AWS resource lifecycle config file and it modifies
eb-env-sync to update the app's resource lifecycle from this new config
file.

The same one config file is shared between all apps.