### PR TITLE
Increase autoscaling limit for h

### DIFF
--- a/h/env-prod.yml
+++ b/h/env-prod.yml
@@ -38,7 +38,7 @@ OptionSettings:
     InstanceType: m4.large
     EC2KeyName: ops
   aws:autoscaling:asg:
-    MaxSize: '6'
+    MaxSize: '12'
     MinSize: '1'
   # Based on constant-load testing against the badge endpoint (which forms our
   # baseline load as of 2017-06-26), a single m4.large instance will begin to


### PR DESCRIPTION
Unfortunately people insist on using our service and we are hitting the
configured threshold of 6 instances max at about the number of
requests/sec expected based on the comment just below this setting.

Slack ops discussion: https://hypothes-is.slack.com/archives/C074BUPEG/p1520344575000082