### PR TITLE
Reduce the application versions limit per app.

### DIFF
--- a/resource-lifecycle.json
+++ b/resource-lifecycle.json
@@ -3,7 +3,7 @@
   "VersionLifecycleConfig": {
     "MaxCountRule": {
       "Enabled": true,
-      "MaxCount": 200,
+      "MaxCount": 10,
       "DeleteSourceFromS3": true
     }
   }


### PR DESCRIPTION
At the moment we have a max limit of 500 versions across all our apps.
We currently have 8 apps on EB. This means that we can keep about 62.5
versions per app.
Reduce that number from 200 to 10 per app to allow for increasing
the number of apps in the future.

See https://hypothes-is.slack.com/archives/C4K6M7P5E/p1531238772000199