### PR TITLE
Add SSM command and instance ID to `eb-task-run` output

### DIFF
--- a/bin/eb-task-run
+++ b/bin/eb-task-run
@@ -59,6 +59,8 @@ if [ "$INSTANCE_ID" = "None" ]; then
   abort "Could not find a running instance for $APP and $ENV"
 fi
 
+status "selected instance $INSTANCE_ID"
+
 
 # Protect instance from a scale-in event
 
@@ -90,6 +92,7 @@ trap "remove_instance_protection '$ASG_NAME' '$INSTANCE_ID'" EXIT
 
 status "initiating command"
 
+OUTPUT_BUCKET_NAME=elasticbeanstalk-run-command-output
 COMMAND_ID=$(aws ssm send-command \
                  --instance-ids "$INSTANCE_ID" \
                  --document-name "AWS-RunShellScript" \
@@ -98,8 +101,8 @@ COMMAND_ID=$(aws ssm send-command \
                      \"commands\": [\"/usr/local/sbin/run-docker-task $COMMAND\"]
                  }" \
                  --query 'Command.CommandId' \
-                 --output-s3-bucket-name 'elasticbeanstalk-run-command-output' \
+                 --output-s3-bucket-name "$OUTPUT_BUCKET_NAME" \
                  --output text)
 
-status "running command"
+status "running command $COMMAND_ID. Output is available in the \"$OUTPUT_BUCKET_NAME\" S3 bucket."
 eb-task-wait "$COMMAND_ID" "$INSTANCE_ID"


### PR DESCRIPTION
In order to view captured stdout/stderr output as a task runs, it is
necessary to know the AWS SSM command ID in order to locate the log
files in S3. Also add a message that is displayed _before_ the task
exits to tell devs where to go looking for command output.

Knowing the EC2 instance ID is also useful if one wishes to monitor a task
more closely (eg. by SSH-ing into the container/VM where it is running).

This should help the next person who wants to track down progress of a long-running app task such as search reindexing.

----

**Testing**

With appropriate AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY env vars set locally, run something like:

```
./bin/eb-task-run h prod 10 "echo foo"
```

Note that `eb-task-run` appears to expect that `python` is Python 3.