### PR TITLE
Add an h task to reindex annotations into Elasticsearch 6

### DIFF
--- a/h/Jenkinsfile-tasks
+++ b/h/Jenkinsfile-tasks
@@ -7,7 +7,8 @@ def tasks = [
     'db upgrade to head (timeout 10m)': [cmd: 'migrate upgrade head', timeout: '600', confirm: true],
     'db upgrade to next (timeout 10m)': [cmd: 'migrate upgrade +1', timeout: '600', confirm: true],
     'db downgrade to previous (timeout 10m)': [cmd: 'migrate downgrade -1', timeout: '600', confirm: true],
-    'search reindex (timeout 4h)': [cmd: 'search reindex', timeout: '14400', confirm: true]
+    'search reindex into Elasticsearch 1 (timeout 4h)': [cmd: 'search reindex', timeout: '14400', confirm: true],
+    'search reindex into Elasticsearch 6 (timeout 4h)': [cmd: 'search reindex --es6', timeout: '14400', confirm: true]
 ]
 
 def taskChoices = tasks.keySet().join('\n')


### PR DESCRIPTION
This can be removed once the upgrade to Elasticsearch 6 is complete.