### PR TITLE
Wait for application version processing to complete in eb-release script

### DIFF
--- a/bin/eb-release
+++ b/bin/eb-release
@@ -102,3 +102,22 @@ aws elasticbeanstalk create-application-version \
     --auto-create-application \
     --query 'ApplicationVersion.VersionLabel' \
     --output text
+
+status "waiting for application version to be processed"
+
+while true; do
+  STATUS=$(aws elasticbeanstalk describe-application-versions \
+               --application-name "$APP" \
+               --version-label "$VERSION_LABEL" \
+               --query 'ApplicationVersions[0].Status' \
+               --output text)
+  if [ "$STATUS" = "PROCESSING" ]; then sleep 2; continue; fi
+  if [ "$STATUS" = "FAILED" ]; then
+    status "application version processing failed"
+    exit 1
+  fi
+
+  break
+done
+
+status "application version ready"


### PR DESCRIPTION
Immediately after the `create-application-version` command is executed, the
application version is in a "Processing" state because of the use of the
`--process` option. Sometimes attempts to deploy this application
version with `./bin/eb-deploy` would fail because the processing had not
yet completed by the time it ran.

Add a polling loop to the end of `./bin/eb-release` to wait until the
new application version is processed before exiting.

This should hopefully fix periodic deployment failures (eg.
https://jenkins.hypothes.is/job/deployment/1067/console).

----

**Testing**

This command can be executed locally for testing purposes as follows:

1. Set AWS credentials for the `aws` CLI tools
2. Run `./bin/eb-release h latest`.

This will create a new application version based on the latest Docker image for h, but won't actually deploy it because that is done by the `./bin/eb-deploy` script.