### PR TITLE
Remove separate Elasticsearch 6 reindex task

### DIFF
--- a/h/Jenkinsfile-tasks
+++ b/h/Jenkinsfile-tasks
@@ -7,8 +7,7 @@ def tasks = [
     'db upgrade to head (timeout 10m)': [cmd: 'migrate upgrade head', timeout: '600', confirm: true],
     'db upgrade to next (timeout 10m)': [cmd: 'migrate upgrade +1', timeout: '600', confirm: true],
     'db downgrade to previous (timeout 10m)': [cmd: 'migrate downgrade -1', timeout: '600', confirm: true],
-    'search reindex into Elasticsearch 1 (timeout 4h)': [cmd: 'search reindex', timeout: '14400', confirm: true],
-    'search reindex into Elasticsearch 6 (timeout 4h)': [cmd: 'search reindex --es6', timeout: '14400', confirm: true]
+    'search reindex (timeout 4h)': [cmd: 'search reindex', timeout: '14400', confirm: true]
 ]
 
 def taskChoices = tasks.keySet().join('\n')


### PR DESCRIPTION
Elasticsearch 6 is now the only search cluster in use and the `--es6` CLI flag
has been removed.