### PR TITLE
Enable streaming of app server instances logs to CloudWatch

### DIFF
--- a/bouncer/env-prod.yml
+++ b/bouncer/env-prod.yml
@@ -5,6 +5,9 @@ EnvironmentTier:
   Type: Standard
   Name: WebServer
 OptionSettings:
+  aws:elasticbeanstalk:cloudwatch:logs:
+    StreamLogs: true
+    RetentionInDays: "7"
   aws:elasticbeanstalk:command:
     DeploymentPolicy: Immutable
   aws:elasticbeanstalk:environment:

--- a/bouncer/env-qa.yml
+++ b/bouncer/env-qa.yml
@@ -5,6 +5,9 @@ EnvironmentTier:
   Type: Standard
   Name: WebServer
 OptionSettings:
+  aws:elasticbeanstalk:cloudwatch:logs:
+    StreamLogs: true
+    RetentionInDays: "7"
   aws:elasticbeanstalk:command:
     DeploymentPolicy: Immutable
   aws:elasticbeanstalk:environment:

--- a/h/env-prod.yml
+++ b/h/env-prod.yml
@@ -5,6 +5,9 @@ EnvironmentTier:
   Type: Standard
   Name: WebServer
 OptionSettings:
+  aws:elasticbeanstalk:cloudwatch:logs:
+    StreamLogs: true
+    RetentionInDays: "7"
   aws:elasticbeanstalk:command:
     DeploymentPolicy: Immutable
   aws:elasticbeanstalk:environment:

--- a/h/env-qa.yml
+++ b/h/env-qa.yml
@@ -5,6 +5,9 @@ EnvironmentTier:
   Type: Standard
   Name: WebServer
 OptionSettings:
+  aws:elasticbeanstalk:cloudwatch:logs:
+    StreamLogs: true
+    RetentionInDays: "7"
   aws:elasticbeanstalk:command:
     DeploymentPolicy: Immutable
   aws:elasticbeanstalk:environment:

--- a/lms/env-prod.yml
+++ b/lms/env-prod.yml
@@ -5,6 +5,9 @@ EnvironmentTier:
   Type: Standard
   Name: WebServer
 OptionSettings:
+  aws:elasticbeanstalk:cloudwatch:logs:
+    StreamLogs: true
+    RetentionInDays: "7"
   aws:elasticbeanstalk:command:
     DeploymentPolicy: Immutable
   aws:elasticbeanstalk:environment:

--- a/lms/env-qa.yml
+++ b/lms/env-qa.yml
@@ -5,6 +5,9 @@ EnvironmentTier:
   Type: Standard
   Name: WebServer
 OptionSettings:
+  aws:elasticbeanstalk:cloudwatch:logs:
+    StreamLogs: true
+    RetentionInDays: "7"
   aws:elasticbeanstalk:command:
     DeploymentPolicy: Immutable
   aws:elasticbeanstalk:environment:

--- a/metabase/env-prod.yml
+++ b/metabase/env-prod.yml
@@ -5,6 +5,9 @@ EnvironmentTier:
   Type: Standard
   Name: WebServer
 OptionSettings:
+  aws:elasticbeanstalk:cloudwatch:logs:
+    StreamLogs: true
+    RetentionInDays: "7"
   aws:elasticbeanstalk:command:
     DeploymentPolicy: Immutable
   aws:elasticbeanstalk:environment:

--- a/metabase/env-qa.yml
+++ b/metabase/env-qa.yml
@@ -5,6 +5,9 @@ EnvironmentTier:
   Type: Standard
   Name: WebServer
 OptionSettings:
+  aws:elasticbeanstalk:cloudwatch:logs:
+    StreamLogs: true
+    RetentionInDays: "7"
   aws:elasticbeanstalk:command:
     DeploymentPolicy: Immutable
   aws:elasticbeanstalk:environment:


### PR DESCRIPTION
Enable the `StreamLogs` option under `aws:elasticbeanstalk:cloudwatch:logs` [1]
for the prod and qa environments for h, bouncer, lms and metabase apps.

Once these changes are applied and app servers are restarted, this will
result in the creation of `/aws/elasticbeanstalk/{app}-{env}/{file
path}` log groups in CloudWatch [2] for centralized archival and searching
of instance logs, including stdout/stderr output from the Docker
container and nginx access and error logs.

I have not turned the option on for Via initially since I think that may
generate a much larger volume of logs and I'd like to get comfortable
with how it is working for the other apps first.

nb. The fact that the retention period is specified as a string not an
integer is required by Elastic Beanstalk's config validation (!)

See also https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.cloudwatchlogs.html

[1] https://docs.aws.amazon.com//elasticbeanstalk/latest/dg/command-options-general.html#command-options-general-cloudwatchlogs
[2] https://us-west-1.console.aws.amazon.com/cloudwatch/home?region=us-west-1#logs: