### PR TITLE
Add dedicated security groups for bouncer app instances

### DIFF
--- a/bouncer/env-prod.yml
+++ b/bouncer/env-prod.yml
@@ -36,7 +36,7 @@ OptionSettings:
     DefaultProcess: default
     Protocol: HTTPS
   aws:autoscaling:launchconfiguration:
-    SecurityGroups: sg-fdf9c19a
+    SecurityGroups: sg-fdf9c19a, sg-08ac4192d01cfc2e7
     IamInstanceProfile: aws-elasticbeanstalk-ec2-role
     InstanceType: t2.nano
     EC2KeyName: ops

--- a/bouncer/env-qa.yml
+++ b/bouncer/env-qa.yml
@@ -36,7 +36,7 @@ OptionSettings:
     DefaultProcess: default
     Protocol: HTTPS
   aws:autoscaling:launchconfiguration:
-    SecurityGroups: sg-fdf9c19a
+    SecurityGroups: sg-fdf9c19a, sg-08ac4192d01cfc2e7
     IamInstanceProfile: aws-elasticbeanstalk-ec2-role
     InstanceType: t2.nano
     EC2KeyName: ops


### PR DESCRIPTION
This will enable giving Bouncer access to resources (eg. Elasticsearch)
without giving other EB services access to them.

See https://hypothes-is.slack.com/archives/C4K6M7P5E/p1544623705096100