### PR TITLE
split ebextensions by environment

### DIFF
--- a/bin/eb-release
+++ b/bin/eb-release
@@ -22,7 +22,7 @@ status () {
     echo "--->" "$@" >&2
 }
 
-if [ "$#" -ne 2 ]; then
+if [ "$#" -ne 3 ]; then
     usage >&2
     exit 1
 fi
@@ -33,6 +33,7 @@ PATH="$(dirname "$0"):${PATH}"
 
 APP=$1
 APP_DOCKER_TAG=$2
+APP_ENV=$3
 
 if [ ! -f "${APP}/Dockerrun.aws.json" ]; then
     abort "there must be a Dockerrun.aws.json in the app directory (${APP}/)"
@@ -66,9 +67,9 @@ if [ -d "common/ebextensions" ]; then
   cp common/ebextensions/*.config "$EBEXTENSIONS"
 fi
 # Allow application to override common ebextensions
-if [ -d "${APP}/ebextensions" ]; then
+if [ -d "${APP}/ebextensions/${APP_ENV}" ]; then
   mkdir -p "$EBEXTENSIONS"
-  cp ${APP}/ebextensions/*.config "$EBEXTENSIONS"
+  cp ${APP}/ebextensions/${APP_ENV}/*.config "$EBEXTENSIONS"
 fi
 
 # And clean up when we're done...

--- a/bin/eb-release
+++ b/bin/eb-release
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 usage () {
-    echo "Usage: $(basename "$0") <APP> <APP_DOCKER_TAG>"
+    echo "Usage: $(basename "$0") <APP> <APP_DOCKER_TAG> <APP_ENV>"
     echo
     echo "Create an application version for the named application using a"
     echo "specified Docker image tag."
@@ -10,6 +10,7 @@ usage () {
     echo
     echo "  APP              the name of the application, e.g. 'bouncer'"
     echo "  APP_DOCKER_TAG   the tag of the Docker image to release"
+    echo "  APP_ENV          the ENV or stage, usuall prod or qa"
 }
 
 abort () {

--- a/bin/jenkins
+++ b/bin/jenkins
@@ -38,7 +38,7 @@ if [ "$TYPE" = "deploy" ]; then
     abort "cannot proceed with deploy unless \$APP_DOCKER_VERSION is specified"
   fi
 
-  version_label=$(eb-release "$APP" "$APP_DOCKER_VERSION")
+  version_label=$(eb-release "$APP" "$APP_DOCKER_VERSION" "$ENV")
   eb-deploy "$APP" "$ENV" "$version_label"
 
 elif [ "$TYPE" = "redeploy" ]; then

--- a/h/ebextensions/qa/papertrail.conf
+++ b/h/ebextensions/qa/papertrail.conf
@@ -1,0 +1,195 @@
+# See http://help.papertrailapp.com/kb/hosting-services/aws-elastic-beanstalk/
+#
+# Usage:
+# - in "sources", replace <VERSION> with the version tag of remote_syslog2 to use (from https://github.com/papertrail/remote_syslog2/releases). For example, replace "<VERSION>" with "v0.18"
+# - in "files", replace <YOUR-TRACKED-FILES> with the files you want to monitor for new log lines. Example:  - /var/log/httpd/access_log
+# - in "files", replace <YOUR-LOG-DESTINATION> and <YOUR-PORT-NUMBER> with the values shown under log destinations: https://papertrailapp.com/account/destinations
+# - the script will set "hostname" automatically. This does not need to be changed.
+# Example log_files.yml: https://github.com/papertrail/remote_syslog2/blob/master/examples/log_files.yml.example
+
+sources:
+  /home/ec2-user: https://github.com/papertrail/remote_syslog2/releases/download/v0.20/remote_syslog_linux_amd64.tar.gz
+
+files:
+  "/etc/log_files.yml":
+    mode: "00644"
+    owner: root
+    group: root
+    encoding: plain
+    content: |
+      files:
+        - /var/log/eb-docker/containers/eb-current-app/*.log
+        - /var/log/nginx/*.log
+      hostname: ##DO_NOT_MODIFY-SETUP_WILL_REPLACE_THIS##
+      destination:
+        host: logs.papertrailapp.com
+        port: 37197
+        protocol: tls
+        
+  "/tmp/set-logger-hostname.sh":
+    mode: "00555"
+    owner: root
+    group: root
+    encoding: plain
+    content: |
+      #!/bin/bash
+      logger_config="/etc/log_files.yml"
+      appname=`{ "Ref" : "AWSEBEnvironmentName" }`
+      instid=`wget -q -O - http://169.254.169.254/latest/meta-data/instance-id`
+      myhostname=${appname}_${instid}
+  
+      if [ -f $logger_config ]; then
+        # Sub the hostname
+        sed "s/hostname:.*/hostname: $myhostname/" -i $logger_config       
+      fi
+ 
+  "/etc/init.d/remote_syslog":
+    mode: "00555"
+    owner: root
+    group: root
+    encoding: plain
+    content: |
+      #!/bin/bash
+      #
+      # remote_syslog This shell script takes care of starting and stopping
+      #               remote_syslog daemon
+      #
+      # chkconfig: - 58 74
+      # description: papertrail/remote_syslog \
+      #              https://github.com/papertrail/remote_syslog2/blob/master/examples/remote_syslog.init.d
+ 
+      ### BEGIN INIT INFO
+      # Provides: remote_syslog
+      # Required-Start: $network $local_fs $remote_fs
+      # Required-Stop: $network $local_fs $remote_fs
+      # Should-Start: $syslog $named ntpdate
+      # Should-Stop: $syslog $named
+      # Short-Description: start and stop remote_errolog
+      # Description: papertrail/remote_syslog2
+      #              https://github.com/papertrail/remote_syslog2/blob/master/examples/remote_syslog.init.d
+      ### END INIT INFO
+ 
+      # Source function library.
+      . /etc/init.d/functions
+ 
+      # Source networking configuration.
+      . /etc/sysconfig/network
+       
+      prog="/usr/local/bin/remote_syslog"   
+      config="/etc/log_files.yml"
+      pid_dir="/var/run"
+ 
+      EXTRAOPTIONS="--poll=true"
+ 
+      pid_file="$pid_dir/remote_syslog.pid"
+ 
+      PATH=/sbin:/bin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
+ 
+      RETVAL=0
+ 
+      is_running(){
+          # Do we have PID-file?
+          if [ -f "$pid_file" ]; then
+              # Check if proc is running
+              pid=`cat "$pid_file" 2> /dev/null`
+              if [[ $pid != "" ]]; then
+                  exepath=`readlink /proc/"$pid"/exe 2> /dev/null`
+                  exe=`basename "$exepath"`
+                  if [[ $exe == "remote_syslog" ]]; then
+                      # Process is running
+                      return 0
+                  fi
+              fi
+          fi
+          return 1
+      }
+ 
+      start(){
+          echo -n $"Starting $prog: "
+          unset HOME MAIL USER USERNAME
+          $prog -c $config --pid-file=$pid_file $EXTRAOPTIONS
+          RETVAL=$?
+          echo
+          return $RETVAL
+      }
+ 
+      stop(){
+          echo -n $"Stopping $prog: "
+          if (is_running); then
+            kill `cat $pid_file`
+            RETVAL=$?
+            echo
+            return $RETVAL
+          else
+            echo "$pid_file not found"
+          fi
+      }
+ 
+      status(){
+          echo -n $"Checking for $pid_file: "
+ 
+          if (is_running); then
+            echo "found"
+          else
+            echo "not found"
+          fi
+      }
+ 
+      reload(){
+          restart
+      }
+ 
+      restart(){
+          stop
+          start
+      }
+ 
+      condrestart(){
+          is_running && restart
+          return 0
+      }
+ 
+      # See how we were called.
+      case "$1" in
+          start)
+        start
+        ;;
+          stop)
+        stop
+        ;;
+          status)
+        status
+        ;;
+          restart)
+        restart
+        ;;
+          reload)
+        reload
+        ;;
+          condrestart)
+        condrestart
+        ;;
+          *)
+        echo $"Usage: $0 {start|stop|status|restart|condrestart|reload}"
+        RETVAL=1
+      esac
+ 
+      exit $RETVAL
+ 
+container_commands:
+  00_stop_service:
+    command: "/sbin/service remote_syslog stop"
+    ignoreErrors: true
+
+  01_set_logger_hostname:
+    command: ". /tmp/set-logger-hostname.sh"
+    
+  02_install_remote_syslog_binary:
+    command: "cp /home/ec2-user/remote_syslog/remote_syslog /usr/local/bin"
+  
+  03_enable_service:
+    command: "/sbin/chkconfig remote_syslog on"
+ 
+  04_start_service:
+    command: "/sbin/service remote_syslog restart"
+    ignoreErrors: true


### PR DESCRIPTION
If applied this will pass the ENV argument from the top level bin/jenkins script to the env-release helper script it calls. That argument is used when it comes time to search for ebextension directory, so that one can test different ebextensions configurations in qa versus prod.