### PR TITLE
add autoscaling and deploy strategy params

### DIFF
--- a/lms/env-prod.yml
+++ b/lms/env-prod.yml
@@ -9,7 +9,9 @@ OptionSettings:
     StreamLogs: true
     RetentionInDays: "7"
   aws:elasticbeanstalk:command:
-    DeploymentPolicy: Immutable
+    DeploymentPolicy: RollingWithAdditionalBatch
+    BatchSizeType: Percentage
+    BatchSize: 100
   aws:elasticbeanstalk:environment:
     EnvironmentType: LoadBalanced
     LoadBalancerType: application
@@ -40,3 +42,6 @@ OptionSettings:
     IamInstanceProfile: aws-elasticbeanstalk-ec2-role
     InstanceType: t2.nano
     EC2KeyName: ops
+  aws:autoscaling:asg:
+    MaxSize: '4'
+    MinSize: '2'


### PR DESCRIPTION
This adds parameters for autoscaling group size and changes the deployment strategy to "rolling with batch" which is already how it is configured in production