### PR TITLE
If applied, this will increase http timeouts in two places for the Me…

### DIFF
--- a/metabase/ebextensions/prod/nginx.config
+++ b/metabase/ebextensions/prod/nginx.config
@@ -1,0 +1,17 @@
+files:
+  "/etc/nginx/conf.d/nginx.custom.conf":
+      mode: "644"
+      owner: "root"
+      group: "root"
+      content: |
+        client_header_timeout   300;
+        client_body_timeout     300;
+        keepalive_timeout       300;
+        send_timeout            300;
+        proxy_connect_timeout   300;
+        proxy_read_timeout      300;
+        proxy_send_timeout      300;
+
+container_commands:
+  01_restart_nginx:
+    command: "sudo service nginx reload"

--- a/metabase/ebextensions/prod/nginx.config
+++ b/metabase/ebextensions/prod/nginx.config
@@ -4,13 +4,7 @@ files:
       owner: "root"
       group: "root"
       content: |
-        client_header_timeout   300;
-        client_body_timeout     300;
-        keepalive_timeout       300;
-        send_timeout            300;
-        proxy_connect_timeout   300;
-        proxy_read_timeout      300;
-        proxy_send_timeout      300;
+        proxy_read_timeout      300s;
 
 container_commands:
   01_restart_nginx:

--- a/metabase/env-prod.yml
+++ b/metabase/env-prod.yml
@@ -43,3 +43,5 @@ OptionSettings:
   aws:autoscaling:asg:
     MaxSize: '1'
     MinSize: '1'
+  aws:elbv2:loadbalancer:
+    IdleTimeout: 300


### PR DESCRIPTION
…tabase elastic beanstalk application. First, it will set the application loadbalancer timeout to 300s. Then it will add an ebextensions configuration file to add a custom NGINX config for all the timeouts, also 300s. Since this is a very low-volume service, that should be a sensible default. This is a stop-gap measure so that queries complete, the next step will be to optimize them so that then never take so long.

https://github.com/hypothesis/playbook/issues/207