### PR TITLE
Add newrelic nginx integration

### DIFF
--- a/h/ebextensions/qa/nri_nginx.conf
+++ b/h/ebextensions/qa/nri_nginx.conf
@@ -57,10 +57,6 @@ files:
         }
 
 commands:
-# create infra config file
-  "00-config-file"
-    command: sudo echo "license_key: d01aa6c88a18eb973fef1127d8eee74e90334341" > "/etc/newrelic-infra.yml"
-
 # Create the agent’s yum repository
   "01-agent-repository":
     command: sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/el/6/x86_64/newrelic-infra.repo

--- a/h/ebextensions/qa/nri_nginx.conf
+++ b/h/ebextensions/qa/nri_nginx.conf
@@ -1,0 +1,85 @@
+### This ebextension will install NewRelic Nginx integration
+
+
+files:
+  "/etc/newrelic-infra.yml" :
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      license_key: d01aa6c88a18eb973fef1127d8eee74e90334341
+
+## Config to enable the Nginx /status endpoint
+
+  "/etc/nginx/conf.d/nginx.custom.conf":
+      mode: "644"
+      owner: "root"
+      group: "root"
+      content: |
+        map $http_upgrade $connection_upgrade {
+            default        "upgrade";
+            ""            "";
+        }
+
+        server {
+            listen 80;
+
+            gzip on;
+                gzip_comp_level 4;
+                gzip_types text/html text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+            if ($time_iso8601 ~ "^(\d{4})-(\d{2})-(\d{2})T(\d{2})") {
+                set $year $1;
+                set $month $2;
+                set $day $3;
+                set $hour $4;
+            }
+            access_log /var/log/nginx/healthd/application.log.$year-$month-$day-$hour healthd;
+
+            access_log    /var/log/nginx/access.log;
+
+            location /status {
+              stub_status on;
+              access_log   off;
+              allow all;
+            }
+
+            location / {
+                proxy_pass            http://docker;
+                proxy_http_version    1.1;
+
+                proxy_set_header    Connection            $connection_upgrade;
+                proxy_set_header    Upgrade                $http_upgrade;
+                proxy_set_header    Host                $host;
+                proxy_set_header    X-Real-IP            $remote_addr;
+                proxy_set_header    X-Forwarded-For        $proxy_add_x_forwarded_for;
+            }
+        }
+
+commands:
+# create infra config file
+  "00-config-file"
+    command: sudo echo "license_key: d01aa6c88a18eb973fef1127d8eee74e90334341" > "/etc/newrelic-infra.yml"
+
+# Create the agent’s yum repository
+  "01-agent-repository":
+    command: sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/el/6/x86_64/newrelic-infra.repo
+
+  "02-update-yum-cache":
+    command: yum -q makecache -y --disablerepo='*' --enablerepo='newrelic-infra'
+
+  "03-run-installation-script":
+    command: sudo yum install newrelic-infra -y 
+
+  "04-install-nginx-integration":
+    command: sudo yum install nri-nginx
+
+  "05-copy-nginx-integration-config":
+    command: sudo cp /etc/newrelic-infra/integrations.d/nginx-config.yml.sample /etc/newrelic-infra/integrations.d/nginx-config.yml
+
+container_commands:
+  "01_restart_nginx":
+    command: "sudo service nginx reload"
+
+  "02-start-infrastructure-agent":
+    command: "sudo initctl start newrelic-infra"

--- a/h/ebextensions/qa/nri_nginx.conf
+++ b/h/ebextensions/qa/nri_nginx.conf
@@ -65,12 +65,9 @@ commands:
     command: yum -q makecache -y --disablerepo='*' --enablerepo='newrelic-infra'
 
   "03-run-installation-script":
-    command: sudo yum install newrelic-infra -y 
+    command: sudo yum install newrelic-infra nri-nginx -y 
 
-  "04-install-nginx-integration":
-    command: sudo yum install nri-nginx
-
-  "05-copy-nginx-integration-config":
+  "04-copy-nginx-integration-config":
     command: sudo cp /etc/newrelic-infra/integrations.d/nginx-config.yml.sample /etc/newrelic-infra/integrations.d/nginx-config.yml
 
 container_commands:


### PR DESCRIPTION
If committed, this ebextension configuraton will install and configure the NewRelic Nginx integration
which sends metrics gathered from the /status endpoint.