### PR TITLE
Increase lms-qa EC2 instance size

### DIFF
--- a/lms/env-qa.yml
+++ b/lms/env-qa.yml
@@ -38,5 +38,5 @@ OptionSettings:
   aws:autoscaling:launchconfiguration:
     SecurityGroups: sg-fdf9c19a,sg-86756ee0
     IamInstanceProfile: aws-elasticbeanstalk-ec2-role
-    InstanceType: t2.nano
+    InstanceType: t3.micro
     EC2KeyName: ops


### PR DESCRIPTION
lms-qa deployments were taking an unexpectedly long time (5-6 minutes).
Observing a deployment indicated this might be due to the instance
running out of memory when two containers (current and new deployment)
were running at once.

Once the new deploy is up and running, everything seemed fine
performance/memory-usage wise.

Attempt to resolve this by increasing the EC2 instance size to one with double the memory (1GB instead of 512MB)