### PR TITLE
Switch lms-qa back to rolling deployments

### DIFF
--- a/h/env-qa.yml
+++ b/h/env-qa.yml
@@ -9,9 +9,7 @@ OptionSettings:
     StreamLogs: true
     RetentionInDays: "7"
   aws:elasticbeanstalk:command:
-    DeploymentPolicy: Rolling  #RollingWithAdditionalBatch #Immutable ## testing
-    # BatchSizeType: Fixed  ## testing
-    #BatchSize: 1 ## testing
+    DeploymentPolicy: Rolling
   aws:elasticbeanstalk:environment:
     EnvironmentType: LoadBalanced
     LoadBalancerType: application
@@ -19,7 +17,7 @@ OptionSettings:
   aws:elasticbeanstalk:environment:process:default:
     HealthCheckPath: /_status
   aws:elasticbeanstalk:healthreporting:system:
-    SystemType: enhanced #basic ## testing
+    SystemType: enhanced
   aws:ec2:vpc:
     Subnets: subnet-0f19e456,subnet-ee2c418b
     VPCId: vpc-bc4d91d9
@@ -42,8 +40,3 @@ OptionSettings:
     IamInstanceProfile: aws-elasticbeanstalk-ec2-role
     InstanceType: t2.micro
     EC2KeyName: ops-20191105
-
-  # aws:elb:policies:  ##testing
-  #   ConnectionDrainingEnabled: true
-  #   ConnectionDrainingTimeout: 10
-

--- a/lms/env-qa.yml
+++ b/lms/env-qa.yml
@@ -9,7 +9,7 @@ OptionSettings:
     StreamLogs: true
     RetentionInDays: "7"
   aws:elasticbeanstalk:command:
-    DeploymentPolicy: Immutable
+    DeploymentPolicy: Rolling
   aws:elasticbeanstalk:environment:
     EnvironmentType: LoadBalanced
     LoadBalancerType: application

--- a/lms/env-qa.yml
+++ b/lms/env-qa.yml
@@ -25,7 +25,7 @@ OptionSettings:
     ELBScheme: public
     AssociatePublicIpAddress: true
   aws:autoscaling:updatepolicy:rollingupdate:
-    RollingUpdateType: Immutable
+    RollingUpdateType: Health
     RollingUpdateEnabled: true
   aws:elbv2:listener:default:
     ListenerEnabled: false


### PR DESCRIPTION
Speed up our deployment process for lms on QA by switching to rolling
deploys. These change was at one point made manually but not committed
to the deployment repo. A recent change to the instance size then
unintentionally reset lms-qa to immutable deploys.

lms-qa and h-qa now use the same deployment settings, aside from
security group references, as shown by:

```
diff -u h/env-qa.yml lms/env-qa.yml
```

I also removed some commented-out configuration from the `h/env-qa.yaml` file.