### PR TITLE
Allow Via deploys to succeed even if some requests fail health checks

### DIFF
--- a/via/env-prod.yml
+++ b/via/env-prod.yml
@@ -15,6 +15,7 @@ OptionSettings:
     HealthCheckPath: /
   aws:elasticbeanstalk:healthreporting:system:
     SystemType: enhanced
+    HealthCheckSuccessThreshold: Degraded
   aws:ec2:vpc:
     Subnets: subnet-0f19e456,subnet-ee2c418b
     VPCId: vpc-bc4d91d9


### PR DESCRIPTION
A large number of requests to Via proxying real-world web pages
naturally fail with 5xx responses due to issues such as:

 - Requests to invalid URLs triggered by incorrect URL rewriting in the
   front-end or non-rewritten URLs
 - Requests to inaccessible or blocked upstream URLs

Therefore in order to be able to deploy Via while the service is busy,
we need to tell AWS not to treat these as a sign of instance
unhealthiness.

This is a band-aid fix. We'll need to find something better as part of
finding a longer-term solution.