### PR TITLE
Set minimum autoscaling group size

### DIFF
--- a/h/env-prod.yml
+++ b/h/env-prod.yml
@@ -42,7 +42,7 @@ OptionSettings:
     EC2KeyName: ops-20191105
   aws:autoscaling:asg:
     MaxSize: '12'
-    MinSize: '1'
+    MinSize: '4'
   # Based on constant-load testing against the badge endpoint (which forms our
   # baseline load as of 2017-06-26), a single m4.large instance will begin to
   # suffer latency degradations as request rates approach 60 req/s,


### PR DESCRIPTION
We don't ever want to have fewer than 4 instances. That is the lowest number we currently reach, and if an incident occurs to reduce traffic temporarily we don't want to have just one instance running when that incident resolves - it takes several minutes to spin them back up.