### PR TITLE
Use Health-based rolling updates for Via

### DIFF
--- a/via/env-qa.yml
+++ b/via/env-qa.yml
@@ -22,7 +22,7 @@ OptionSettings:
     ELBScheme: public
     AssociatePublicIpAddress: true
   aws:autoscaling:updatepolicy:rollingupdate:
-    RollingUpdateType: Immutable
+    RollingUpdateType: Health
     RollingUpdateEnabled: true
   aws:elbv2:listener:default:
     ListenerEnabled: false


### PR DESCRIPTION
Attempting to use "Immutable" rolling updates together with rolling
deployments appears not to be compatible. An env-sync task for
via/env-qa.yml failed with:

```
2019-12-13 16:53:14 UTC  ERROR  To enable immutable config and
application deployments together, you must set both the DeploymentPolicy
option (aws:elasticbeanstalk:command namespace) and the
RollingUpdateType option (aws:autoscaling:updatepolicy:rollingupdate
namespace) to Immutable.
```

See https://jenkins.hypothes.is/job/deployment/3104/console.

Since we want rolling deployments, change the rolling update mode to one
that is compatible with that.