### PR TITLE
Fix h-qa rolling update type

### DIFF
--- a/h/env-qa.yml
+++ b/h/env-qa.yml
@@ -25,7 +25,7 @@ OptionSettings:
     ELBScheme: public
     AssociatePublicIpAddress: true
   aws:autoscaling:updatepolicy:rollingupdate:
-    RollingUpdateType: Immutable
+    RollingUpdateType: Health
     RollingUpdateEnabled: true
   aws:elbv2:listener:default:
     ListenerEnabled: false


### PR DESCRIPTION
The "Immutable" rolling update type is not compatible with the "Rolling"
deployment type. Change it to "Health" which matches lms-qa and via-qa.

The fact that these settings are incompatible presumably means that the
actual h-qa environment configuration was not in sync with h/env-qa.yml.

See also https://github.com/hypothesis/deployment/pull/60