### PR TITLE
Increase EC2 instance size for h-qa

### DIFF
--- a/h/env-qa.yml
+++ b/h/env-qa.yml
@@ -38,5 +38,5 @@ OptionSettings:
   aws:autoscaling:launchconfiguration:
     SecurityGroups: sg-fdf9c19a,sg-a6073fc1
     IamInstanceProfile: aws-elasticbeanstalk-ec2-role
-    InstanceType: t2.micro
+    InstanceType: t3a.small
     EC2KeyName: ops-20191105


### PR DESCRIPTION
An h-qa deploy failed due to a Docker container running out of memory
(see [1]). h-qa currently seems to use 500-700MB of memory on an
instance type that has 1GB of memory. This can be insufficient if
activity causes a spike in usage or during a deploy when a rolling
update occurs and two instances of the app are briefly running at the
same time.

Bump up the instance size to a t3a.small instead (_which has 2GB of memory for an on-demand instance at a cost of ~$6/month more. See https://aws.amazon.com/ec2/pricing/on-demand/_)

[1] https://hypothes-is.slack.com/archives/C074BUPEG/p1576593903011100