### PR TITLE
Update h-qa platform version

### DIFF
--- a/h/env-qa.yml
+++ b/h/env-qa.yml
@@ -1,6 +1,6 @@
 AWSConfigurationTemplateVersion: 1.1.0.0
 Platform:
-  PlatformArn: arn:aws:elasticbeanstalk:us-west-1::platform/Docker running on 64bit Amazon Linux/2.7.0
+  PlatformArn: arn:aws:elasticbeanstalk:us-west-1::platform/Docker running on 64bit Amazon Linux/2.14.0
 EnvironmentTier:
   Type: Standard
   Name: WebServer


### PR DESCRIPTION
This change has already been applied to the EB environment. It was
required to use t3* instance types.

See https://hypothes-is.slack.com/archives/C4K6M7P5E/p1576595852040800