### PR TITLE
Remove immutable autoscaling on py-proxy qa

### DIFF
--- a/py-proxy/env-qa.yml
+++ b/py-proxy/env-qa.yml
@@ -25,7 +25,7 @@ OptionSettings:
     ELBScheme: public
     AssociatePublicIpAddress: true
   aws:autoscaling:updatepolicy:rollingupdate:
-    RollingUpdateType: Immutable
+    RollingUpdateType: Health
     RollingUpdateEnabled: true
   aws:elbv2:listener:default:
     ListenerEnabled: false


### PR DESCRIPTION
If the deployment type is “Rolling”, the rolling update type can’t be Immutable. Change it to Health instead.