### PR TITLE
Increase the number of via3 prod instances and size

### DIFF
--- a/py-proxy/env-prod.yml
+++ b/py-proxy/env-prod.yml
@@ -43,5 +43,5 @@ OptionSettings:
     InstanceType: t3.micro
     EC2KeyName: ops-20191105
   aws:autoscaling:asg:
-    MaxSize: '4'
-    MinSize: '2'
+    MaxSize: '12'
+    MinSize: '4'

--- a/py-proxy/env-prod.yml
+++ b/py-proxy/env-prod.yml
@@ -40,7 +40,7 @@ OptionSettings:
   aws:autoscaling:launchconfiguration:
     SecurityGroups: sg-fdf9c19a
     IamInstanceProfile: aws-elasticbeanstalk-ec2-role
-    InstanceType: t3.micro
+    InstanceType: t3.small
     EC2KeyName: ops-20191105
   aws:autoscaling:asg:
     MaxSize: '12'

--- a/py-proxy/env-qa.yml
+++ b/py-proxy/env-qa.yml
@@ -38,5 +38,5 @@ OptionSettings:
   aws:autoscaling:launchconfiguration:
     SecurityGroups: sg-fdf9c19a
     IamInstanceProfile: aws-elasticbeanstalk-ec2-role
-    InstanceType: t3.micro
+    InstanceType: t3.small
     EC2KeyName: ops-20191105


### PR DESCRIPTION
Increase the number of via3 production instances & their sizes:
* Start with 4 and set autoscaling to go up to 12.
* Increase instance size from t3.micro to t3.small.
This is a partial fix for https://github.com/hypothesis/py-proxy/issues/15.