### PR TITLE
Send *everything* in /var/log/ to Papertrail

### DIFF
--- a/via3/ebextensions/qa/papertrail.config
+++ b/via3/ebextensions/qa/papertrail.config
@@ -18,8 +18,7 @@ files:
     encoding: plain
     content: |
       files:
-        - /var/log/eb-docker/containers/eb-current-app/*.log
-        - /var/log/nginx/*.log
+        - /var/log/**/*
       hostname: ##DO_NOT_MODIFY-SETUP_WILL_REPLACE_THIS##
       destination:
         host: logs.papertrailapp.com


### PR DESCRIPTION
Attempt to send all log files in /var/log/ to Papertrail, not just some of them. Trying this with Via 3 QA as a test.