### PR TITLE
Revert "Send *everything* in /var/log/ to Papertrail"

### DIFF
--- a/via3/ebextensions/qa/papertrail.config
+++ b/via3/ebextensions/qa/papertrail.config
@@ -18,7 +18,8 @@ files:
     encoding: plain
     content: |
       files:
-        - /var/log/**/*
+        - /var/log/eb-docker/containers/eb-current-app/*.log
+        - /var/log/nginx/*.log
       hostname: ##DO_NOT_MODIFY-SETUP_WILL_REPLACE_THIS##
       destination:
         host: logs.papertrailapp.com


### PR DESCRIPTION
Reverts hypothesis/deployment#75. This doesn't seem to have worked: I'm not seeing _anything_ for QA Via 3 in Papertrail anymore. QA Via 3 is also responding really slowly.