### PR TITLE
Revert "Also capture logs from /var/log/* files (not in a subdir)"

### DIFF
--- a/via3/ebextensions/qa/papertrail.config
+++ b/via3/ebextensions/qa/papertrail.config
@@ -18,7 +18,6 @@ files:
     encoding: plain
     content: |
       files:
-        - /var/log/*
         - /var/log/**/*
       hostname: ##DO_NOT_MODIFY-SETUP_WILL_REPLACE_THIS##
       destination:


### PR DESCRIPTION
Reverts hypothesis/deployment#78. I'm not sure that this change was actually necessary. Rather, the `/var/log/**/*` wasn't working because it hadn't actually been deployed successfully. So I'm gonna try reverting this, and see if things still work without it