### PR TITLE
Revert "Revert "Also capture logs from /var/log/* files (not in a subdir)""

### DIFF
--- a/via3/ebextensions/qa/papertrail.config
+++ b/via3/ebextensions/qa/papertrail.config
@@ -18,6 +18,7 @@ files:
     encoding: plain
     content: |
       files:
+        - /var/log/*
         - /var/log/**/*
       hostname: ##DO_NOT_MODIFY-SETUP_WILL_REPLACE_THIS##
       destination:


### PR DESCRIPTION
Reverts hypothesis/deployment#81. Nope -- looks like you actually _do_ need `/var/log/*` as well as `/var/log/**/*`, otherwise it fails to catch all the top-level files. Lots of log files totally stopped appearing in Papertrail when I deployed this. Reverting it.