### PR TITLE
Remove public ips from instances

### DIFF
--- a/bouncer/env-prod.yml
+++ b/bouncer/env-prod.yml
@@ -23,7 +23,7 @@ OptionSettings:
     VPCId: vpc-bc4d91d9
     ELBSubnets: subnet-9bf985c3,subnet-3b21015f
     ELBScheme: public
-    AssociatePublicIpAddress: true
+    AssociatePublicIpAddress: false
   aws:autoscaling:updatepolicy:rollingupdate:
     RollingUpdateType: Immutable
     RollingUpdateEnabled: true

--- a/bouncer/env-qa.yml
+++ b/bouncer/env-qa.yml
@@ -23,7 +23,7 @@ OptionSettings:
     VPCId: vpc-bc4d91d9
     ELBSubnets: subnet-9bf985c3,subnet-3b21015f
     ELBScheme: public
-    AssociatePublicIpAddress: true
+    AssociatePublicIpAddress: false
   aws:autoscaling:updatepolicy:rollingupdate:
     RollingUpdateType: Health
     RollingUpdateEnabled: true

--- a/h/env-prod.yml
+++ b/h/env-prod.yml
@@ -23,7 +23,7 @@ OptionSettings:
     VPCId: vpc-bc4d91d9
     ELBSubnets: subnet-9bf985c3,subnet-3b21015f
     ELBScheme: public
-    AssociatePublicIpAddress: true
+    AssociatePublicIpAddress: false
   aws:autoscaling:updatepolicy:rollingupdate:
     RollingUpdateType: Immutable
     RollingUpdateEnabled: true

--- a/h/env-qa.yml
+++ b/h/env-qa.yml
@@ -23,7 +23,7 @@ OptionSettings:
     VPCId: vpc-bc4d91d9
     ELBSubnets: subnet-9bf985c3,subnet-3b21015f
     ELBScheme: public
-    AssociatePublicIpAddress: true
+    AssociatePublicIpAddress: false
   aws:autoscaling:updatepolicy:rollingupdate:
     RollingUpdateType: Health
     RollingUpdateEnabled: true

--- a/lms/env-prod.yml
+++ b/lms/env-prod.yml
@@ -25,7 +25,7 @@ OptionSettings:
     VPCId: vpc-bc4d91d9
     ELBSubnets: subnet-9bf985c3,subnet-3b21015f
     ELBScheme: public
-    AssociatePublicIpAddress: true
+    AssociatePublicIpAddress: false
   aws:autoscaling:updatepolicy:rollingupdate:
     RollingUpdateType: Immutable
     RollingUpdateEnabled: true

--- a/lms/env-qa.yml
+++ b/lms/env-qa.yml
@@ -23,7 +23,7 @@ OptionSettings:
     VPCId: vpc-bc4d91d9
     ELBSubnets: subnet-9bf985c3,subnet-3b21015f
     ELBScheme: public
-    AssociatePublicIpAddress: true
+    AssociatePublicIpAddress: false
   aws:autoscaling:updatepolicy:rollingupdate:
     RollingUpdateType: Health
     RollingUpdateEnabled: true

--- a/metabase/env-prod.yml
+++ b/metabase/env-prod.yml
@@ -23,7 +23,7 @@ OptionSettings:
     VPCId: vpc-bc4d91d9
     ELBSubnets: subnet-9bf985c3,subnet-3b21015f
     ELBScheme: public
-    AssociatePublicIpAddress: true
+    AssociatePublicIpAddress: false
   aws:autoscaling:updatepolicy:rollingupdate:
     RollingUpdateType: Immutable
     RollingUpdateEnabled: true

--- a/metabase/env-qa.yml
+++ b/metabase/env-qa.yml
@@ -23,7 +23,7 @@ OptionSettings:
     VPCId: vpc-bc4d91d9
     ELBSubnets: subnet-9bf985c3,subnet-3b21015f
     ELBScheme: public
-    AssociatePublicIpAddress: true
+    AssociatePublicIpAddress: false
   aws:autoscaling:updatepolicy:rollingupdate:
     RollingUpdateType: Immutable
     RollingUpdateEnabled: true

--- a/via/env-prod.yml
+++ b/via/env-prod.yml
@@ -21,7 +21,7 @@ OptionSettings:
     VPCId: vpc-bc4d91d9
     ELBSubnets: subnet-9bf985c3,subnet-3b21015f
     ELBScheme: public
-    AssociatePublicIpAddress: true
+    AssociatePublicIpAddress: false
   aws:autoscaling:updatepolicy:rollingupdate:
     RollingUpdateType: Immutable
     RollingUpdateEnabled: true

--- a/via/env-prod.yml
+++ b/via/env-prod.yml
@@ -15,7 +15,7 @@ OptionSettings:
     HealthCheckPath: /
   aws:elasticbeanstalk:healthreporting:system:
     SystemType: enhanced
-    HealthCheckSuccessThreshold: Degraded
+    HealthCheckSuccessThreshold: Severe
   aws:ec2:vpc:
     Subnets: subnet-0f19e456,subnet-ee2c418b
     VPCId: vpc-bc4d91d9

--- a/via/env-qa.yml
+++ b/via/env-qa.yml
@@ -20,7 +20,7 @@ OptionSettings:
     VPCId: vpc-bc4d91d9
     ELBSubnets: subnet-9bf985c3,subnet-3b21015f
     ELBScheme: public
-    AssociatePublicIpAddress: true
+    AssociatePublicIpAddress: false
   aws:autoscaling:updatepolicy:rollingupdate:
     RollingUpdateType: Health
     RollingUpdateEnabled: true

--- a/via3/env-prod.yml
+++ b/via3/env-prod.yml
@@ -25,7 +25,7 @@ OptionSettings:
     VPCId: vpc-bc4d91d9
     ELBSubnets: subnet-9bf985c3,subnet-3b21015f
     ELBScheme: public
-    AssociatePublicIpAddress: true
+    AssociatePublicIpAddress: false
   aws:autoscaling:updatepolicy:rollingupdate:
     RollingUpdateType: Immutable
     RollingUpdateEnabled: true

--- a/via3/env-qa.yml
+++ b/via3/env-qa.yml
@@ -23,7 +23,7 @@ OptionSettings:
     VPCId: vpc-bc4d91d9
     ELBSubnets: subnet-9bf985c3,subnet-3b21015f
     ELBScheme: public
-    AssociatePublicIpAddress: true
+    AssociatePublicIpAddress: false
   aws:autoscaling:updatepolicy:rollingupdate:
     RollingUpdateType: Health
     RollingUpdateEnabled: true


### PR DESCRIPTION
This PR will strip instances of public IP addresses so that they can only be accessed from the Load Balancer (or from a bastion host within the private network). This reduces our attack surface and prevents us from accidentally leaving a security group open to the public as has happened a few times recently. In rare cases where we need to connect to an instance directly, we can assign it an Elastic IP address and temporarily open the security group. 

There is a second commit to change the HealthCheck threshold for VIA to SEVERE, meaning it won't fail the deploy for DEGRADED and below. This is because VIA can get marked degraded in normal use if it's returning a lot of 400s. This config change has already been made manually in the console. 