### PR TITLE
Increase LMS prod instance size to t3.small

### DIFF
--- a/lms/env-prod.yml
+++ b/lms/env-prod.yml
@@ -40,7 +40,7 @@ OptionSettings:
   aws:autoscaling:launchconfiguration:
     SecurityGroups: sg-fdf9c19a,sg-86756ee0
     IamInstanceProfile: aws-elasticbeanstalk-ec2-role
-    InstanceType: t2.nano
+    InstanceType: t3.small
     EC2KeyName: ops-20191105
   aws:autoscaling:asg:
     MaxSize: '4'


### PR DESCRIPTION
I'd like to increase LMS's instance size because (wild stab in the dark)
I think running out of memory might be a possible cause of DB connection
issues it seems to have been having. It currently uses 2-4 t2.nano's
which have only 512mb memory. That seems absurd -- we shouldn't be
trying to run our apps on 512mb. As a start I think we should increase
it to t3.small which has 2GB. I think that'll cost about $300 per year.

For comparison, h uses 4-12 m4.large's, legacy Via uses 10-20
t3.micro's,  Via 3 uses 4-12 t3.small's (and is currently just sitting
there, not even being used in production!).