### PR TITLE
Add empty Volumes array to bouncer/Dockerrun.aws.json

### DIFF
--- a/bouncer/Dockerrun.aws.json
+++ b/bouncer/Dockerrun.aws.json
@@ -7,5 +7,6 @@
     {
       "ContainerPort": "8000"
     }
-  ]
+  ],
+  "Volumes": []
 }


### PR DESCRIPTION
We're hoping that this will get rid of an error from `jq` that we're
seeing during bouncer QA deployments, and that it might even fix bouncer
QA deployments (which are currently failing):

    jq: error (at <stdin>:11): Cannot iterate over null (null)