### PR TITLE
Downgrade bouncer QA to Amazon Linux 2.14.0

### DIFF
--- a/bouncer/env-qa.yml
+++ b/bouncer/env-qa.yml
@@ -1,6 +1,6 @@
 AWSConfigurationTemplateVersion: 1.1.0.0
 Platform:
-  PlatformArn: arn:aws:elasticbeanstalk:us-west-1::platform/Docker running on 64bit Amazon Linux/2.14.1
+  PlatformArn: arn:aws:elasticbeanstalk:us-west-1::platform/Docker running on 64bit Amazon Linux/2.14.0
 EnvironmentTier:
   Type: Standard
   Name: WebServer


### PR DESCRIPTION
This is the version that bouncer prod is using, and bouncer QA should be
the same as bouncer prod. Also, deploying to bouncer QA is currently
broken and we're hoping that this will fix it.