### PR TITLE
Upgrade bouncer QA to Amazon Linux 2.14.2

### DIFF
--- a/bouncer/env-qa.yml
+++ b/bouncer/env-qa.yml
@@ -1,6 +1,6 @@
 AWSConfigurationTemplateVersion: 1.1.0.0
 Platform:
-  PlatformArn: arn:aws:elasticbeanstalk:us-west-1::platform/Docker running on 64bit Amazon Linux/2.14.0
+  PlatformArn: arn:aws:elasticbeanstalk:us-west-1::platform/Docker running on 64bit Amazon Linux/2.14.2
 EnvironmentTier:
   Type: Standard
   Name: WebServer


### PR DESCRIPTION
Downgrading from 2.14.1 to 2.14.0 has not fixed the problem with bouncer
QA deployments. So try upgrading to 2.14.2 (the latest version) instead.
This is a stab in the dark, but worth a shot