### PR TITLE
Change bouncer QA's instance type fto t3.small

### DIFF
--- a/bouncer/env-qa.yml
+++ b/bouncer/env-qa.yml
@@ -38,6 +38,6 @@ OptionSettings:
   aws:autoscaling:launchconfiguration:
     SecurityGroups: sg-fdf9c19a, sg-08ac4192d01cfc2e7
     IamInstanceProfile: aws-elasticbeanstalk-ec2-role
-    InstanceType: t2.nano
+    InstanceType: t3.small
     EC2KeyName: ops-20191105
 


### PR DESCRIPTION
This is another stab in the dark at fixing bouncer QA deploys. I'm not
hopeful that this will work, but it's worth a shot