### PR TITLE
Sync h and via deployment policies with Elastic Beanstalk

### DIFF
--- a/h/env-prod.yml
+++ b/h/env-prod.yml
@@ -9,7 +9,9 @@ OptionSettings:
     StreamLogs: true
     RetentionInDays: "7"
   aws:elasticbeanstalk:command:
-    DeploymentPolicy: Immutable
+    DeploymentPolicy: RollingWithAdditionalBatch
+    BatchSizeType: Percentage
+    BatchSize: '100'
   aws:elasticbeanstalk:environment:
     EnvironmentType: LoadBalanced
     LoadBalancerType: application

--- a/via/env-prod.yml
+++ b/via/env-prod.yml
@@ -6,7 +6,9 @@ EnvironmentTier:
   Name: WebServer
 OptionSettings:
   aws:elasticbeanstalk:command:
-    DeploymentPolicy: Immutable
+    DeploymentPolicy: RollingWithAdditionalBatch
+    BatchSizeType: Percentage
+    BatchSize: '100'
   aws:elasticbeanstalk:environment:
     EnvironmentType: LoadBalanced
     LoadBalancerType: application


### PR DESCRIPTION
These were set to Immutable in this repo, but are actually set to
RollingWithAdditionalBatch (and a batch size of 100%) in Elastic
Beanstalk.