### PR TITLE
Adding blank newrelic configuration for monitoring Via3

### DIFF
--- a/lms/ebextensions/prod/newrelic.config
+++ b/lms/ebextensions/prod/newrelic.config
@@ -6,7 +6,7 @@ files:
     owner: root
     group: root
     content: |
-      license_key: YOUR_LICENSE_KEY
+      license_key: `{"Fn::GetOptionSetting": {"Namespace": "aws:elasticbeanstalk:application:environment", "OptionName": "NEW_RELIC_LICENCE_KEY"}}`
 
 commands:
 # Create the agent’s yum repository

--- a/lms/ebextensions/prod/newrelic.config
+++ b/lms/ebextensions/prod/newrelic.config
@@ -1,0 +1,22 @@
+# From: https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/installation/install-infrastructure-agent-aws-elastic-beanstalk
+
+files:
+  "/etc/newrelic-infra.yml" :
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      license_key: YOUR_LICENSE_KEY
+
+commands:
+# Create the agent’s yum repository
+  "01-agent-repository":
+    command: sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/el/6/x86_64/newrelic-infra.repo
+#
+# Update your yum cache
+  "02-update-yum-cache":
+    command: yum -q makecache -y --disablerepo='*' --enablerepo='newrelic-infra'
+#
+# Run the installation script
+  "03-run-installation-script":
+    command: sudo yum install newrelic-infra -y

--- a/lms/ebextensions/qa/newrelic.config
+++ b/lms/ebextensions/qa/newrelic.config
@@ -6,7 +6,7 @@ files:
     owner: root
     group: root
     content: |
-      license_key: YOUR_LICENSE_KEY
+      license_key: `{"Fn::GetOptionSetting": {"Namespace": "aws:elasticbeanstalk:application:environment", "OptionName": "NEW_RELIC_LICENCE_KEY"}}`
 
 commands:
 # Create the agent’s yum repository

--- a/lms/ebextensions/qa/newrelic.config
+++ b/lms/ebextensions/qa/newrelic.config
@@ -1,0 +1,22 @@
+# From: https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/installation/install-infrastructure-agent-aws-elastic-beanstalk
+
+files:
+  "/etc/newrelic-infra.yml" :
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      license_key: YOUR_LICENSE_KEY
+
+commands:
+# Create the agent’s yum repository
+  "01-agent-repository":
+    command: sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/el/6/x86_64/newrelic-infra.repo
+#
+# Update your yum cache
+  "02-update-yum-cache":
+    command: yum -q makecache -y --disablerepo='*' --enablerepo='newrelic-infra'
+#
+# Run the installation script
+  "03-run-installation-script":
+    command: sudo yum install newrelic-infra -y


### PR DESCRIPTION
This should enable host level monitoring of all (one) containers deployed for Via 3.

This is from: https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/installation/install-infrastructure-agent-aws-elastic-beanstalk

----

I've just dumped the example files in for now as I'm not sure if it's a terrible idea to put in our license key in the clear.