### PR TITLE
Add NGINX integration to the New Relic agent in QA

### DIFF
--- a/via3/ebextensions/qa/newrelic.config
+++ b/via3/ebextensions/qa/newrelic.config
@@ -29,8 +29,7 @@ files:
           - name: via3-qa-nginx
             command: metrics
             arguments:
-              # See: https://discuss.newrelic.com/t/nginx-integration-username-password/55274
-              status_url: http://via3_stats:@`{"Fn::GetOptionSetting": {"Namespace": "aws:elasticbeanstalk:application:environment", "OptionName": "NGINX_STATS_PASSWORD"}}`${discovery.ip}:${discovery.port}/status
+              status_url: http://${discovery.ip}:${discovery.port}/_stats
               status_module: discover
               remote_monitoring: true
             labels:

--- a/via3/ebextensions/qa/newrelic.config
+++ b/via3/ebextensions/qa/newrelic.config
@@ -5,8 +5,37 @@ files:
     mode: "000644"
     owner: root
     group: root
+    # See: https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/configuration/infrastructure-config-file-template-newrelic-infrayml
+    # And: https://docs.newrelic.com/docs/infrastructure/install-configure-manage-infrastructure/configuration/infrastructure-configuration-settings
+    # And: https://stackoverflow.com/questions/29423608/accessing-environment-variables-in-aws-beanstalk-ebextensions/54221973#54221973
     content: |
+      display_name: via3-qa
       license_key: `{"Fn::GetOptionSetting": {"Namespace": "aws:elasticbeanstalk:application:environment", "OptionName": "NEW_RELIC_LICENCE_KEY"}}`
+
+  "/etc/newrelic-infra/integrations.d/nginx-config.yml" :
+    mode: "000644"
+    owner: root
+    group: root
+    # From: https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-nginx_linux_2.0.1_amd64.tar.gz
+    # See: https://docs.newrelic.com/docs/integrations/host-integrations/installation/container-auto-discovery
+    # And: https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/nginx-monitoring-integration#config
+    content: |
+      integration_name: com.newrelic.nginx
+        discovery:
+          docker:
+            match:
+              image: /via3/
+        instances:
+          - name: via3-qa-nginx
+            command: metrics
+            arguments:
+              # See: https://discuss.newrelic.com/t/nginx-integration-username-password/55274
+              status_url: http://via3_stats:@`{"Fn::GetOptionSetting": {"Namespace": "aws:elasticbeanstalk:application:environment", "OptionName": "NGINX_STATS_PASSWORD"}}`${discovery.ip}:${discovery.port}/status
+              status_module: discover
+              remote_monitoring: true
+            labels:
+              env: ${discovery.label.env}
+              role: ${discovery.label.role}
 
 commands:
 # Create the agent’s yum repository


### PR DESCRIPTION
This attempts to:

 * Add a sensible name for reporting
 * Add NGINX integration

For: https://github.com/hypothesis/via3/issues/21

This requires: https://github.com/hypothesis/via3/pull/164

**TODO!** - Add the password to EB as NGINX_STATS_PASSWORD