### PR TITLE
Add back Via3 NGINX monitoring qa 4

### DIFF
--- a/via3/ebextensions/qa/newrelic.config
+++ b/via3/ebextensions/qa/newrelic.config
@@ -9,10 +9,10 @@ files:
     # And: https://docs.newrelic.com/docs/infrastructure/install-configure-manage-infrastructure/configuration/infrastructure-configuration-settings
     # And: https://stackoverflow.com/questions/29423608/accessing-environment-variables-in-aws-beanstalk-ebextensions/54221973#54221973
     content: |
-      display_name: via3-qa
+      display_name: `{"Fn::GetOptionSetting": {"Namespace": "aws:elasticbeanstalk:application:environment", "OptionName": "NEW_RELIC_APP_NAME"}}`
       license_key: `{"Fn::GetOptionSetting": {"Namespace": "aws:elasticbeanstalk:application:environment", "OptionName": "NEW_RELIC_LICENSE_KEY"}}`
       custom_attributes:
-        environment: qa
+        environment: `{"Fn::GetOptionSetting": {"Namespace": "aws:elasticbeanstalk:application:environment", "OptionName": "NEW_RELIC_ENVIRONMENT"}}`
 
 
   "/etc/newrelic-infra/integrations.d/nginx-config.yml" :
@@ -27,7 +27,7 @@ files:
         discovery:
           docker:
             match:
-              image: /via3/
+              port: 9083
         instances:
           - name: via3-qa-nginx
             command: metrics
@@ -36,7 +36,7 @@ files:
               status_module: discover
               remote_monitoring: true
             labels:
-              env: qa
+              env: `{"Fn::GetOptionSetting": {"Namespace": "aws:elasticbeanstalk:application:environment", "OptionName": "NEW_RELIC_ENVIRONMENT"}}`
               role: via3-reverse-proxy
 
 commands:


### PR DESCRIPTION
An example of the output of `docker ps` from EB

  ```
 CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS               NAMES
   3e5e5bd34930        f670809f0e47        "/bin/sh -c '/usr/bi…"   17 hours ago        Up 17 hours         9083/tcp            quizzical_benz
```
Looks like nothing is preserved but the port.

Also trying to set some names from variables floating about. Maybe something will happen
if these values line up?