### PR TITLE
New Relic 5: Add logging to try and work out what happened

### DIFF
--- a/via3/ebextensions/qa/newrelic.config
+++ b/via3/ebextensions/qa/newrelic.config
@@ -11,6 +11,7 @@ files:
     content: |
       display_name: `{"Fn::GetOptionSetting": {"Namespace": "aws:elasticbeanstalk:application:environment", "OptionName": "NEW_RELIC_APP_NAME"}}`
       license_key: `{"Fn::GetOptionSetting": {"Namespace": "aws:elasticbeanstalk:application:environment", "OptionName": "NEW_RELIC_LICENSE_KEY"}}`
+      log_file: /var/log/new-relic-agent.log
       custom_attributes:
         environment: `{"Fn::GetOptionSetting": {"Namespace": "aws:elasticbeanstalk:application:environment", "OptionName": "NEW_RELIC_ENVIRONMENT"}}`
 


### PR DESCRIPTION
New Relic provides no log rotation, and I've not added it here, so this will expand until it destroys everything. So we'll have to turn this off or add rotation if it works.