### PR TITLE
via3 iptables - block rfc1918 ip ranges

### DIFF
--- a/via3/ebextensions/qa/50_iptables_block_docker_metadata.config
+++ b/via3/ebextensions/qa/50_iptables_block_docker_metadata.config
@@ -5,5 +5,8 @@
 commands:
   10_insert_iptables_metadata_block:
     command: iptables --insert DOCKER-USER --destination 169.254.169.254 --jump REJECT
+    command: iptables --insert DOCKER-USER --destination 10.0.0.0/8 --jump REJECT
+    command: iptables --insert DOCKER-USER --destination 172.16.0.0/12 --jump REJECT
+    command: iptables --insert DOCKER-USER --destination 192.168.0.0/16 --jump REJECT
   20_persist_iptables:
     command: iptables-save > /etc/sysconfig/iptables

--- a/via3/ebextensions/qa/50_iptables_block_docker_metadata.config
+++ b/via3/ebextensions/qa/50_iptables_block_docker_metadata.config
@@ -4,9 +4,15 @@
 
 commands:
   10_insert_iptables_metadata_block:
+    # Block ec2metadata service
     command: iptables --insert DOCKER-USER --destination 169.254.169.254 --jump REJECT
+    # Block RFC 1918 private IP ranges
     command: iptables --insert DOCKER-USER --destination 10.0.0.0/8 --jump REJECT
     command: iptables --insert DOCKER-USER --destination 172.16.0.0/12 --jump REJECT
     command: iptables --insert DOCKER-USER --destination 192.168.0.0/16 --jump REJECT
+    # Block all accept TCP Ports 80 and 443
+    command: iptables --insert DOCKER-USER --protocol tcp --match tcp --match multiport ! --destination-ports 80,443 -j REJECT
+    # Allow UDP Port 53
+    command: iptables --insert DOCKER-USER --protocol udp --destination-port 53 --jump ACCEPT
   20_persist_iptables:
     command: iptables-save > /etc/sysconfig/iptables

--- a/via3/ebextensions/qa/50_iptables_block_docker_metadata.config
+++ b/via3/ebextensions/qa/50_iptables_block_docker_metadata.config
@@ -10,7 +10,7 @@ commands:
     command: iptables --insert DOCKER-USER --destination 10.0.0.0/8 --jump REJECT
     command: iptables --insert DOCKER-USER --destination 172.16.0.0/12 --jump REJECT
     command: iptables --insert DOCKER-USER --destination 192.168.0.0/16 --jump REJECT
-    # Block all accept TCP Ports 80 and 443
+    # Block all except TCP Ports 80 and 443
     command: iptables --insert DOCKER-USER --protocol tcp --match tcp --match multiport ! --destination-ports 80,443 -j REJECT
     # Allow UDP Port 53
     command: iptables --insert DOCKER-USER --protocol udp --destination-port 53 --jump ACCEPT


### PR DESCRIPTION
Hi Guys,

This branch should address _most_ of what Jon is requesting in https://github.com/hypothesis/via3/issues/218

It will add the RFC1918 public IP address ranges to the DOCKER-USER iptables chain, and REJECT traffic from the container to those addresses.

**The update has only be done for QA. If this works I will create another branch for the prod update.**

What this doesn't address:

1. IPv6 - Our AWS VPC does not support IPv6 so I don't think that configuration is necessary.
2. Safe Ports. The [squid.conf](https://github.com/hypothesis/via/blob/master/conf/squid.conf) referenced in Jon's request defines a series of safe ports. Do we think these are necessary? I don't confess to understand exactly what via3 is doing, but my basic understand is it provides an HTTP proxy service for those that can not use the H client. If that is the case, shouldn't we only allow HTTP and HTTPS access?

```
acl SSL_ports port 443
acl Safe_ports port 80		# http
acl Safe_ports port 21		# ftp
acl Safe_ports port 443		# https
acl Safe_ports port 70		# gopher
acl Safe_ports port 210		# wais
acl Safe_ports port 1025-65535	# unregistered ports
acl Safe_ports port 280		# http-mgmt
acl Safe_ports port 488		# gss-http
acl Safe_ports port 591		# filemaker
acl Safe_ports port 777		# multiling http
```

**IPTABLES DOCKER-USER chain prior to this update**
```
[root@ip-10-1-3-250 ~]# iptables -L DOCKER-USER -n -v
Chain DOCKER-USER (1 references)
 pkts bytes target     prot opt in     out     source               destination
   12   720 REJECT     all  --  *      *       0.0.0.0/0            169.254.169.254      reject-with icmp-port-unreachable
1419K  522M RETURN     all  --  *      *       0.0.0.0/0            0.0.0.0/0
```

Hope this all makes sense. Let me know if you have any questions!

