### PR TITLE
via3 iptables - updated ebextension formatting

### DIFF
--- a/via3/ebextensions/qa/50_iptables_block_docker_metadata.config
+++ b/via3/ebextensions/qa/50_iptables_block_docker_metadata.config
@@ -1,18 +1,26 @@
-## This adds a rule to iptables at the DOCKER-USER chain which all traffic from which
-## all traffic from the container to outside networks must pass. That rule blocks
-## the IP of the ec2metadata service so as to not expose sensitive auth tokens etc.
+## This adds rules to iptables at the DOCKER-USER chain which all traffic from which
+## the container to outside networks must pass. 
+## The rules block:
+## - the IP of the aws ec2metadata service
+## - 10.0.0.0/8 private ip range
+## - 172.16.0.0/12 private ip range
+## - 192.168.0.0/16 private ip range
+## - all tcp ports except 80 and 443
+## The rules allow:
+## - udp port 53 for dns queries
 
 commands:
-  10_insert_iptables_metadata_block:
-    # Block ec2metadata service
+  10_insert_iptables_aws_metadata_service_reject:
     command: iptables --insert DOCKER-USER --destination 169.254.169.254 --jump REJECT
-    # Block RFC 1918 private IP ranges
+  20_insert_iptables_10.0.0.0/8_reject:
     command: iptables --insert DOCKER-USER --destination 10.0.0.0/8 --jump REJECT
+  30_insert_iptables_172.16.0.0/12_reject:
     command: iptables --insert DOCKER-USER --destination 172.16.0.0/12 --jump REJECT
+  40_insert_iptables_192.168.0.0/16_reject:
     command: iptables --insert DOCKER-USER --destination 192.168.0.0/16 --jump REJECT
-    # Block all except TCP Ports 80 and 443
+  50_insert_iptables_block_all_except_80_443:
     command: iptables --insert DOCKER-USER --protocol tcp --match tcp --match multiport ! --destination-ports 80,443 -j REJECT
-    # Allow UDP Port 53
+  60_insert_iptables_allow_dns_53:
     command: iptables --insert DOCKER-USER --protocol udp --destination-port 53 --jump ACCEPT
-  20_persist_iptables:
+  70_persist_iptables:
     command: iptables-save > /etc/sysconfig/iptables


### PR DESCRIPTION
The formatting of the `ebextension` on the last branch was incorrect. This branch addresses that.

I have removed the inline comments because I think the formatting speaks for itself. Detailed comments about the function of the script can be found at the top of the file.