### PR TITLE
via3 - iptables qa revert

### DIFF
--- a/via3/ebextensions/qa/50_iptables_block_docker_metadata.config
+++ b/via3/ebextensions/qa/50_iptables_block_docker_metadata.config
@@ -1,26 +1,9 @@
-## This adds rules to iptables at the DOCKER-USER chain which all traffic from which
-## the container to outside networks must pass. 
-## The rules block:
-## - the IP of the aws ec2metadata service
-## - 10.0.0.0/8 private ip range
-## - 172.16.0.0/12 private ip range
-## - 192.168.0.0/16 private ip range
-## - all tcp ports except 80 and 443
-## The rules allow:
-## - udp port 53 for dns queries
+## This adds a rule to iptables at the DOCKER-USER chain which all traffic from which
+## all traffic from the container to outside networks must pass. That rule blocks
+## the IP of the ec2metadata service so as to not expose sensitive auth tokens etc.
 
 commands:
-  10_insert_iptables_aws_metadata_service_reject:
+  10_insert_iptables_metadata_block:
     command: iptables --insert DOCKER-USER --destination 169.254.169.254 --jump REJECT
-  20_insert_iptables_10.0.0.0/8_reject:
-    command: iptables --insert DOCKER-USER --destination 10.0.0.0/8 --jump REJECT
-  30_insert_iptables_172.16.0.0/12_reject:
-    command: iptables --insert DOCKER-USER --destination 172.16.0.0/12 --jump REJECT
-  40_insert_iptables_192.168.0.0/16_reject:
-    command: iptables --insert DOCKER-USER --destination 192.168.0.0/16 --jump REJECT
-  50_insert_iptables_block_all_except_80_443:
-    command: iptables --insert DOCKER-USER --protocol tcp --match tcp --match multiport ! --destination-ports 80,443 -j REJECT
-  60_insert_iptables_allow_dns_53:
-    command: iptables --insert DOCKER-USER --protocol udp --destination-port 53 --jump ACCEPT
-  70_persist_iptables:
+  20_persist_iptables:
     command: iptables-save > /etc/sysconfig/iptables


### PR DESCRIPTION
Unfortunately I looking to revert the `iptables` rules on via3 qa. I have detailed my reasoning in on the original issue: https://github.com/hypothesis/via3/issues/218#issuecomment-672778118 

This branch reinstates the configuration as it was before testing was started.

Let me know if you have any questions. 