### PR TITLE
analytics-dashboard-qa - newrelic ebextension update

### DIFF
--- a/analytics-dashboard/ebextensions/qa/100_new_relic_infra_agent.config
+++ b/analytics-dashboard/ebextensions/qa/100_new_relic_infra_agent.config
@@ -18,12 +18,14 @@ files:
 
       if [ -z "$key" ] ; then
         echo "NEW_RELIC_LICENSE_KEY is empty"
-        exit 1
+        echo "Can not continue with NewRelic configuration - Set license key"
+        exit 0
       fi
 
       if [ -z "$display_name" ] ; then
         echo "NEW_RELIC_APP_NAME is empty"
-        exit 2
+        echo "Can not continue with NewRelic configuration - Set app name"
+        exit 0
       else
         # Start building the configuration file...
         echo "Creating NewRelic configuration file"


### PR DESCRIPTION
Changed exit codes as they will cause a new environment build to fail
if the newrelic configuration properties have not been set. You can not
set the required properties until the environment is has been built.