### PR TITLE
EB Definition - Change H-Prod instance type

### DIFF
--- a/h/env-prod.yml
+++ b/h/env-prod.yml
@@ -40,11 +40,11 @@ OptionSettings:
   aws:autoscaling:launchconfiguration:
     SecurityGroups: sg-fdf9c19a,sg-a6073fc1
     IamInstanceProfile: aws-elasticbeanstalk-ec2-role
-    InstanceType: m4.large
+    InstanceType: m5.large
     EC2KeyName: ops-20191105
   aws:autoscaling:asg:
     MaxSize: '18'
-    MinSize: '4'
+    MinSize: '8'
   # Based on constant-load testing against the badge endpoint (which forms our
   # baseline load as of 2017-06-26), a single m4.large instance will begin to
   # suffer latency degradations as request rates approach 60 req/s,


### PR DESCRIPTION
The change switches the EC2 instance type being used for H-Prod.
We are migrating from M4.Large to M5.Large. The change provides a more
performant CPU at a slightly reduced cost per hour.

In addition, this update brings our configuration in-line with a
manually updated configuration made whilst troubleshooting performance
issues. The minimum number of instances we now run for H is `8`. This
may be reduced at some point in the future when we have a better
understanding of how the environment is performing under increased load.