### PR TITLE
Elastic Beanstalk - Via3 QA Ebextension - NginX proxy_buffer config.

### DIFF
--- a/via3/ebextensions/qa/60_proxy_buffers.config
+++ b/via3/ebextensions/qa/60_proxy_buffers.config
@@ -1,0 +1,16 @@
+# This ebextension modifies the default behaviour of NGINX as it is
+# shipped via Elastic Beanstalk. We are configuring a series of proxy
+# parameters that enable Via to handle large headers that the likes of
+# twitter and youtube send back.
+files:
+  "/etc/nginx/conf.d/01-proxy_buffers.conf" :
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      proxy_buffer_size          128k;
+      proxy_buffers              4 256k;
+      proxy_busy_buffers_size    256k;
+container_commands:
+  nginx_reload:
+    command: "service nginx reload"


### PR DESCRIPTION
This branch delivers a new ebextension for via3 in qa only. The
extension configures a series of proxy parameters that enable us to
handle the large headers sent back by the likes of twitter and youtube.

Further details can be found here: https://github.com/hypothesis/via3/issues/250