### PR TITLE
Elastic Beanstalk - Via3 Ebextension - NginX proxy_buffer config.

### DIFF
--- a/via3/ebextensions/prod/60_proxy_buffers.config
+++ b/via3/ebextensions/prod/60_proxy_buffers.config
@@ -15,6 +15,3 @@ files:
       proxy_buffer_size          128k;
       proxy_buffers              4 256k;
       proxy_busy_buffers_size    256k;
-container_commands:
-  nginx_reload:
-    command: "service nginx reload"

--- a/via3/ebextensions/qa/60_proxy_buffers.config
+++ b/via3/ebextensions/qa/60_proxy_buffers.config
@@ -15,6 +15,3 @@ files:
       proxy_buffer_size          128k;
       proxy_buffers              4 256k;
       proxy_busy_buffers_size    256k;
-container_commands:
-  nginx_reload:
-    command: "service nginx reload"


### PR DESCRIPTION
This branch troubleshoots the previous branch I created for the Via3
ebextension. For a reason that I can not explain the extension
successfully deploys to qa. However, it fails when deploying to
production.

I have done some reading, and I can see others having also experienced similar problems with ebextensions and nginx. https://stackoverflow.com/questions/40766708/issue-with-aws-beanstalk-command

The advice has been to remove the container commands that perform the reload of nginx. This is because nginx restarts after every successful deployment.
