### PR TITLE
Switch metabase to rolling deployments and remove nginx reload command

### DIFF
--- a/metabase/ebextensions/prod/nginx.config
+++ b/metabase/ebextensions/prod/nginx.config
@@ -5,7 +5,3 @@ files:
       group: "root"
       content: |
         proxy_read_timeout      300s;
-
-container_commands:
-  01_restart_nginx:
-    command: "sudo service nginx reload"

--- a/metabase/env-prod.yml
+++ b/metabase/env-prod.yml
@@ -9,7 +9,7 @@ OptionSettings:
     StreamLogs: true
     RetentionInDays: "7"
   aws:elasticbeanstalk:command:
-    DeploymentPolicy: Immutable
+    DeploymentPolicy: Rolling
   aws:elasticbeanstalk:environment:
     EnvironmentType: LoadBalanced
     LoadBalancerType: application

--- a/metabase/env-qa.yml
+++ b/metabase/env-qa.yml
@@ -9,7 +9,7 @@ OptionSettings:
     StreamLogs: true
     RetentionInDays: "7"
   aws:elasticbeanstalk:command:
-    DeploymentPolicy: Immutable
+    DeploymentPolicy: Rolling
   aws:elasticbeanstalk:environment:
     EnvironmentType: LoadBalanced
     LoadBalancerType: application


### PR DESCRIPTION
This PR fixes a couple of issues I encountered yesterday while trying to [fix issues](https://hypothes-is.slack.com/archives/CR3E3S7K8/p1600710016012700) with metabase by doing a redeployment:

- Metabase currently uses slow immutable deployments for both qa + prod instead of the much faster rolling deployments that we use for other services. This PR switches both qa + prod to use rolling. See commit message for more details.
- I removed an `nginx reload` command which [caused a deployment failure](https://jenkins.hypothes.is/job/deployment/2571/console) when the last attempt to deploy metabase happened and which is also unnecessary (see commit message)

Related issue: https://github.com/hypothesis/playbook/issues/395.