### PR TITLE
Sync load balancer timeout with active configuration

### DIFF
--- a/metabase/env-prod.yml
+++ b/metabase/env-prod.yml
@@ -44,4 +44,4 @@ OptionSettings:
     MaxSize: '1'
     MinSize: '1'
   aws:elbv2:loadbalancer:
-    IdleTimeout: 300
+    IdleTimeout: '600'


### PR DESCRIPTION
Fix a syntax error in `metabase/env-prod.yml` which caused an error
during deployment:

```
Parameter validation failed:
Invalid type for parameter OptionSettings[27].Value, value: 300, type:
<class 'int'>, valid types: <class 'str'>
```

Also change the value from 300 to 600, since 600 is the value of the
running load balancer instance, which was presumably configured
manually.

Docs: https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html#command-options-general-elbv2