### PR TITLE
Change metabase rolling update type

### DIFF
--- a/metabase/env-prod.yml
+++ b/metabase/env-prod.yml
@@ -25,7 +25,7 @@ OptionSettings:
     ELBScheme: public
     AssociatePublicIpAddress: true
   aws:autoscaling:updatepolicy:rollingupdate:
-    RollingUpdateType: Immutable
+    RollingUpdateType: Health
     RollingUpdateEnabled: true
   aws:elbv2:listener:default:
     ListenerEnabled: false

--- a/metabase/env-qa.yml
+++ b/metabase/env-qa.yml
@@ -25,7 +25,7 @@ OptionSettings:
     ELBScheme: public
     AssociatePublicIpAddress: true
   aws:autoscaling:updatepolicy:rollingupdate:
-    RollingUpdateType: Immutable
+    RollingUpdateType: Health
     RollingUpdateEnabled: true
   aws:elbv2:listener:default:
     ListenerEnabled: false


### PR DESCRIPTION
In order to use the `Rolling` deployment mode, the `RollingUpdateType`
value must be set to `Health`. Otherwise deployment encounters an error:

```
ERROR  Cannot update resource configuration and instance configuration
simultaneously with immutable updates. Choose a different rolling update
type and redeploy to make this change.
```

See previous commit 3acc6fc0e3e3a1293af87c941f8e55a81ae9a102 for more
details, where the same change was made for other environments.