### PR TITLE
Switch metabase-prod to a larger instance type

### DIFF
--- a/metabase/env-prod.yml
+++ b/metabase/env-prod.yml
@@ -1,6 +1,6 @@
 AWSConfigurationTemplateVersion: 1.1.0.0
 Platform:
-  PlatformArn: arn:aws:elasticbeanstalk:us-west-1::platform/Docker running on 64bit Amazon Linux/2.12.8
+  PlatformArn: arn:aws:elasticbeanstalk:us-west-1::platform/Docker running on 64bit Amazon Linux/2.14.0
 EnvironmentTier:
   Type: Standard
   Name: WebServer
@@ -38,7 +38,7 @@ OptionSettings:
   aws:autoscaling:launchconfiguration:
     SecurityGroups: sg-fdf9c19a,sg-816374e6
     IamInstanceProfile: aws-elasticbeanstalk-ec2-role
-    InstanceType: t2.micro
+    InstanceType: t3.small
     EC2KeyName: ops-20191105
   aws:autoscaling:asg:
     MaxSize: '1'

--- a/metabase/env-qa.yml
+++ b/metabase/env-qa.yml
@@ -1,6 +1,6 @@
 AWSConfigurationTemplateVersion: 1.1.0.0
 Platform:
-  PlatformArn: arn:aws:elasticbeanstalk:us-west-1::platform/Docker running on 64bit Amazon Linux/2.7.0
+  PlatformArn: arn:aws:elasticbeanstalk:us-west-1::platform/Docker running on 64bit Amazon Linux/2.14.0
 EnvironmentTier:
   Type: Standard
   Name: WebServer
@@ -38,7 +38,7 @@ OptionSettings:
   aws:autoscaling:launchconfiguration:
     SecurityGroups: sg-fdf9c19a,sg-816374e6
     IamInstanceProfile: aws-elasticbeanstalk-ec2-role
-    InstanceType: t2.micro
+    InstanceType: t3.micro
     EC2KeyName: ops-20191105
   aws:autoscaling:asg:
     MaxSize: '1'


### PR DESCRIPTION
Switching to an instance type with more memory should hopefully resolve a
deployment failure. Also switch from T2 => T3 instances for lower costs
for a given instance size. This required updating the platform version
to one that we know supports T3 instances.