### PR TITLE
Increase metabase qa instance size

### DIFF
--- a/metabase/env-qa.yml
+++ b/metabase/env-qa.yml
@@ -38,7 +38,7 @@ OptionSettings:
   aws:autoscaling:launchconfiguration:
     SecurityGroups: sg-fdf9c19a,sg-816374e6
     IamInstanceProfile: aws-elasticbeanstalk-ec2-role
-    InstanceType: t3.micro
+    InstanceType: t3.small
     EC2KeyName: ops-20191105
   aws:autoscaling:asg:
     MaxSize: '1'


### PR DESCRIPTION
Update metabase qa from a micro to a small instance as we have already
done for metabase prod.

This will hopefully resolve an issue during deployment:

```
Native memory allocation (mmap) failed to map 53780480 bytes for
committing reserved memory.
```

Discussion at https://discourse.metabase.com/t/minimum-requirements-to-host-metabase-tool/6712/3 suggests that 1GB is a sensible minimum so if there are multiple instances during a deployment, you really need 2GB.