### PR TITLE
Elastic Beanstalk Definition - ViaHTML3

### DIFF
--- a/viahtml3/env-prod.yml
+++ b/viahtml3/env-prod.yml
@@ -40,7 +40,7 @@ OptionSettings:
   aws:autoscaling:launchconfiguration:
     SecurityGroups: sg-fdf9c19a
     IamInstanceProfile: aws-elasticbeanstalk-ec2-role
-    InstanceType: t3.micro
+    InstanceType: t3.small
     EC2KeyName: ops-20191105
   aws:autoscaling:asg:
     MaxSize: '4'

--- a/viahtml3/env-qa.yml
+++ b/viahtml3/env-qa.yml
@@ -38,5 +38,5 @@ OptionSettings:
   aws:autoscaling:launchconfiguration:
     SecurityGroups: sg-fdf9c19a
     IamInstanceProfile: aws-elasticbeanstalk-ec2-role
-    InstanceType: t3.nano
+    InstanceType: t3.small
     EC2KeyName: ops-20191105


### PR DESCRIPTION
This update delivers a change to the Elastic Beanstalk definition for
ViaHTML3 in both QA and Production. The instance type has been changed
to t3.small.