### PR TITLE
Ebextension - H-QA - 80_nginx_workers.config

### DIFF
--- a/h/ebextensions/qa/80_nginx_workers.config
+++ b/h/ebextensions/qa/80_nginx_workers.config
@@ -1,0 +1,36 @@
+# ebextension to deliver a custom nginx configuration.
+# We are introducing 2 changes...
+# 1. Introduce the worker_rlimit_nofile parameter with a value of 1536
+# 2. Increase worker_connections to 1536
+files:
+  "/etc/nginx/nginx.conf" :
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      # Custom Elastic Beanstalk Nginx Configuration File
+      # Delivered by ebextension 80_nginx_workers.config
+
+      user  nginx;
+      worker_processes  auto;
+      worker_rlimit_nofile 1536;
+
+      error_log  /var/log/nginx/error.log;
+
+      pid        /var/run/nginx.pid;
+
+      events {
+          worker_connections  1536;
+      }
+
+      http {
+          include       /etc/nginx/mime.types;
+          default_type  application/octet-stream;
+
+          access_log    /var/log/nginx/access.log;
+
+          log_format  healthd '$msec"$uri"$status"$request_time"$upstream_response_time"$http_x_forwarded_for';
+
+          include       /etc/nginx/conf.d/*.conf;
+          include       /etc/nginx/sites-enabled/*;
+      }


### PR DESCRIPTION
This branch delivers an ebextension that provisions a custom nginx.conf
for H-QA only.

We are introducing 2 changes:

1. Increase `worker_connections` to `1536`
2. Introducing the `worker_rlimit_nofile` parameter with a value of `1536`

These parameters are being tuned due to the recent performance problems we have been experiencing. 