### PR TITLE
Speed up h-periodic deploys

### DIFF
--- a/h-periodic/env-prod.yml
+++ b/h-periodic/env-prod.yml
@@ -6,7 +6,7 @@ EnvironmentTier:
   Name: WebServer
 OptionSettings:
   aws:elasticbeanstalk:command:
-    DeploymentPolicy: Immutable
+    DeploymentPolicy: RollingWithAdditionalBatch
   aws:elasticbeanstalk:environment:
     EnvironmentType: LoadBalanced
     LoadBalancerType: application

--- a/h-periodic/env-qa.yml
+++ b/h-periodic/env-qa.yml
@@ -6,7 +6,7 @@ EnvironmentTier:
   Name: WebServer
 OptionSettings:
   aws:elasticbeanstalk:command:
-    DeploymentPolicy: Immutable
+    DeploymentPolicy: Rolling
   aws:elasticbeanstalk:environment:
     EnvironmentType: LoadBalanced
     LoadBalancerType: application


### PR DESCRIPTION
h-periodic takes a really long time to deploy because it uses immutable deploys