### PR TITLE
Make Via3 and ViaHTML papertrail logs the same as H and Via

### DIFF
--- a/via3/ebextensions/prod/papertrail.config
+++ b/via3/ebextensions/prod/papertrail.config
@@ -18,8 +18,8 @@ files:
     encoding: plain
     content: |
       files:
-        - /var/log/*
-        - /var/log/**/*
+        - /var/log/eb-docker/containers/eb-current-app/*.log
+        - /var/log/nginx/*.log
       hostname: ##DO_NOT_MODIFY-SETUP_WILL_REPLACE_THIS##
       destination:
         host: logs.papertrailapp.com

--- a/via3/ebextensions/qa/papertrail.config
+++ b/via3/ebextensions/qa/papertrail.config
@@ -18,8 +18,8 @@ files:
     encoding: plain
     content: |
       files:
-        - /var/log/*
-        - /var/log/**/*
+        - /var/log/eb-docker/containers/eb-current-app/*.log
+        - /var/log/nginx/*.log
       hostname: ##DO_NOT_MODIFY-SETUP_WILL_REPLACE_THIS##
       destination:
         host: logs.papertrailapp.com

--- a/viahtml/ebextensions/prod/papertrail.config
+++ b/viahtml/ebextensions/prod/papertrail.config
@@ -18,8 +18,8 @@ files:
     encoding: plain
     content: |
       files:
-        - /var/log/*
-        - /var/log/**/*
+        - /var/log/eb-docker/containers/eb-current-app/*.log
+        - /var/log/nginx/*.log
       hostname: ##DO_NOT_MODIFY-SETUP_WILL_REPLACE_THIS##
       destination:
         host: logs.papertrailapp.com

--- a/viahtml/ebextensions/qa/papertrail.config
+++ b/viahtml/ebextensions/qa/papertrail.config
@@ -18,8 +18,8 @@ files:
     encoding: plain
     content: |
       files:
-        - /var/log/*
-        - /var/log/**/*
+        - /var/log/eb-docker/containers/eb-current-app/*.log
+        - /var/log/nginx/*.log
       hostname: ##DO_NOT_MODIFY-SETUP_WILL_REPLACE_THIS##
       destination:
         host: logs.papertrailapp.com


### PR DESCRIPTION
Here we have a branch that changes the papertrail logging for viahtml in both prod and qa. We are including the container and nginx logs.