### PR TITLE
Elastic Beanstalk - ViaHTML Environment Definition

### DIFF
--- a/viahtml/env-prod.yml
+++ b/viahtml/env-prod.yml
@@ -45,3 +45,13 @@ OptionSettings:
   aws:autoscaling:asg:
     MaxSize: '4'
     MinSize: '2'
+  aws:autoscaling:trigger:
+    MeasureName: CPUUtilization
+    Statistic: Average
+    Unit: Percent
+    Period: '2'
+    EvaluationPeriods: '2'
+    UpperThreshold: '60'
+    UpperBreachScaleIncrement: '1'
+    LowerThreshold: '30'
+    LowerBreachScaleIncrement: '-1'


### PR DESCRIPTION
Setting the autoscaling trigger to `CPUUtilization`. Scaling-out when
the CPU AVG goes above 60% and scaling-in when it drops below 30%.