### PR TITLE
h-websocket - EB environment definition update.

### DIFF
--- a/h-websocket/env-prod.yml
+++ b/h-websocket/env-prod.yml
@@ -1,6 +1,6 @@
 AWSConfigurationTemplateVersion: 1.1.0.0
 Platform:
-  PlatformArn: arn:aws:elasticbeanstalk:us-west-1::platform/64bit Amazon Linux 2 v3.2.0 running Docker/3.2.0
+  PlatformArn: arn:aws:elasticbeanstalk:us-west-1::platform/64bit Amazon Linux 2 v3.2.0 running Docker
 EnvironmentTier:
   Type: Standard
   Name: WebServer

--- a/h-websocket/env-qa.yml
+++ b/h-websocket/env-qa.yml
@@ -1,6 +1,6 @@
 AWSConfigurationTemplateVersion: 1.1.0.0
 Platform:
-  PlatformArn: arn:aws:elasticbeanstalk:us-west-1::platform/64bit Amazon Linux 2 v3.2.0 running Docker/3.2.0
+  PlatformArn: arn:aws:elasticbeanstalk:us-west-1::platform/64bit Amazon Linux 2 v3.2.0 running Docker
 EnvironmentTier:
   Type: Standard
   Name: WebServer


### PR DESCRIPTION
The `PlatformArn` was incorrectly defined in the previous commit.