### PR TITLE
EB Definition - Checkmate - Access hardening

### DIFF
--- a/checkmate/env-prod.yml
+++ b/checkmate/env-prod.yml
@@ -37,6 +37,8 @@ OptionSettings:
     SSLCertificateArns: arn:aws:acm:us-west-1:964867326460:certificate/ef36b626-66e0-495e-813c-71a3b883f692
     DefaultProcess: default
     Protocol: HTTPS
+  aws:elbv2:loadbalancer:
+    SecurityGroups: sg-0fb3e01d26a27a182
   aws:autoscaling:launchconfiguration:
     SecurityGroups: sg-fdf9c19a
     IamInstanceProfile: aws-elasticbeanstalk-ec2-role

--- a/checkmate/env-qa.yml
+++ b/checkmate/env-qa.yml
@@ -35,6 +35,8 @@ OptionSettings:
     SSLCertificateArns: arn:aws:acm:us-west-1:964867326460:certificate/ef36b626-66e0-495e-813c-71a3b883f692
     DefaultProcess: default
     Protocol: HTTPS
+  aws:elbv2:loadbalancer:
+    SecurityGroups: sg-0fb3e01d26a27a182
   aws:autoscaling:launchconfiguration:
     SecurityGroups: sg-fdf9c19a
     IamInstanceProfile: aws-elasticbeanstalk-ec2-role


### PR DESCRIPTION
This branch delivers an update to the Checkmate EB definitions. A new
security group has been introduced that only permits access from our
private subnets or the Cloudflare edge nodes.