### PR TITLE
EB Definition - Checkmate

### DIFF
--- a/checkmate/env-prod.yml
+++ b/checkmate/env-prod.yml
@@ -34,7 +34,7 @@ OptionSettings:
   aws:elbv2:listener:443:
     ListenerEnabled: true
     SSLPolicy: ELBSecurityPolicy-TLS-1-2-2017-01
-    SSLCertificateArns: arn:aws:acm:us-west-1:964867326460:certificate/ef36b626-66e0-495e-813c-71a3b883f692
+    SSLCertificateArns: arn:aws:acm:us-west-1:964867326460:certificate/10a99c23-3115-4fa6-b73d-3ec7f3967b81
     DefaultProcess: default
     Protocol: HTTPS
   aws:elbv2:loadbalancer:

--- a/checkmate/env-qa.yml
+++ b/checkmate/env-qa.yml
@@ -32,7 +32,7 @@ OptionSettings:
   aws:elbv2:listener:443:
     ListenerEnabled: true
     SSLPolicy: ELBSecurityPolicy-TLS-1-2-2017-01
-    SSLCertificateArns: arn:aws:acm:us-west-1:964867326460:certificate/ef36b626-66e0-495e-813c-71a3b883f692
+    SSLCertificateArns: arn:aws:acm:us-west-1:964867326460:certificate/10a99c23-3115-4fa6-b73d-3ec7f3967b81
     DefaultProcess: default
     Protocol: HTTPS
   aws:elbv2:loadbalancer:


### PR DESCRIPTION
This branch delivers an update to the SSL certificate being used by the
load-balancers hosting checkmate. We are going to be using the
`*.srv.hypothes.is` wildcard cert.