### PR TITLE
EBextension update - Removed access logs

### DIFF
--- a/checkmate/ebextensions/prod/papertrail.config
+++ b/checkmate/ebextensions/prod/papertrail.config
@@ -19,7 +19,6 @@ files:
     content: |
       files:
         - /var/log/eb-docker/containers/eb-current-app/*.log
-        - /var/log/nginx/*.log
       hostname: ##DO_NOT_MODIFY-SETUP_WILL_REPLACE_THIS##
       destination:
         host: logs.papertrailapp.com

--- a/checkmate/ebextensions/qa/papertrail.config
+++ b/checkmate/ebextensions/qa/papertrail.config
@@ -19,7 +19,6 @@ files:
     content: |
       files:
         - /var/log/eb-docker/containers/eb-current-app/*.log
-        - /var/log/nginx/*.log
       hostname: ##DO_NOT_MODIFY-SETUP_WILL_REPLACE_THIS##
       destination:
         host: logs.papertrailapp.com

--- a/viahtml/ebextensions/prod/papertrail.config
+++ b/viahtml/ebextensions/prod/papertrail.config
@@ -19,7 +19,6 @@ files:
     content: |
       files:
         - /var/log/eb-docker/containers/eb-current-app/*.log
-        - /var/log/nginx/*.log
       hostname: ##DO_NOT_MODIFY-SETUP_WILL_REPLACE_THIS##
       destination:
         host: logs.papertrailapp.com

--- a/viahtml/ebextensions/qa/papertrail.config
+++ b/viahtml/ebextensions/qa/papertrail.config
@@ -19,7 +19,6 @@ files:
     content: |
       files:
         - /var/log/eb-docker/containers/eb-current-app/*.log
-        - /var/log/nginx/*.log
       hostname: ##DO_NOT_MODIFY-SETUP_WILL_REPLACE_THIS##
       destination:
         host: logs.papertrailapp.com


### PR DESCRIPTION
As per our discussion: https://hypothes-is.slack.com/archives/C4K6M7P5E/p1605865607400500

We decided not to push access logs to papertrail for our proxy applications.