### PR TITLE
EBExtension - ViaHTML IP Tables

### DIFF
--- a/viahtml/ebextensions/prod/50_iptables.config
+++ b/viahtml/ebextensions/prod/50_iptables.config
@@ -1,0 +1,46 @@
+## Extension to deploy firewall script and execute
+##
+## FIREWALL SCRIPT EXPLAINED
+## 01. Set container_ip_one variable 
+## 02. Set container_ip_two variable 
+## 03. Flush the DOCKER-USER user-defined iptables chain
+## 04. Insert a default reject policy
+## 05. Reject the 10.0.0.0/8 RFC1918 IP address space
+## 06. Reject the 172.16.0.0/12 RFC1918 IP address space
+## 07. Reject the 192.168.0.0./16 RFC1918 IP address space
+## 08. Reject the AWS metadata service
+## 09. Accept connections where:
+## --- Container_ip_one equals DESTINATION IP
+## 10. Accept connections where:
+## --- Container_ip_one equals SOURCE IP
+## 11. Accept connections where:
+## --- Container_ip_two equals DESTINATION IP
+## 12. Accept connections where:
+## --- Container_ip_two equals SOURCE IP
+## 13. Accept ALL UDP DNS Traffic
+## 14. Save iptables rules
+##
+files:
+  "/root/firewall.sh" :
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      container_ip_one='172.17.0.2'
+      container_ip_two='172.17.0.3'
+      iptables --flush DOCKER-USER
+      iptables --insert DOCKER-USER --jump REJECT
+      iptables --insert DOCKER-USER --destination 10.0.0.0/8 --jump REJECT
+      iptables --insert DOCKER-USER --destination 172.16.0.0/12 --jump REJECT
+      iptables --insert DOCKER-USER --destination 192.168.0.0/16 --jump REJECT
+      iptables --insert DOCKER-USER --destination 169.254.169.254 --jump REJECT
+      iptables --insert DOCKER-USER --protocol tcp --destination $container_ip_one --jump ACCEPT
+      iptables --insert DOCKER-USER --protocol tcp --source $container_ip_one --jump ACCEPT
+      iptables --insert DOCKER-USER --protocol tcp --destination $container_ip_two --jump ACCEPT
+      iptables --insert DOCKER-USER --protocol tcp --source $container_ip_two --jump ACCEPT
+      iptables --insert DOCKER-USER --protocol udp --destination-port 53 --jump ACCEPT
+      iptables --insert DOCKER-USER --protocol udp --source-port 53 --jump ACCEPT
+      iptables-save > /etc/sysconfig/iptables
+container_commands:
+  firewall:
+    command: "sh /root/firewall.sh"

--- a/viahtml/ebextensions/qa/50_iptables.config
+++ b/viahtml/ebextensions/qa/50_iptables.config
@@ -1,0 +1,46 @@
+## Extension to deploy firewall script and execute
+##
+## FIREWALL SCRIPT EXPLAINED
+## 01. Set container_ip_one variable 
+## 02. Set container_ip_two variable 
+## 03. Flush the DOCKER-USER user-defined iptables chain
+## 04. Insert a default reject policy
+## 05. Reject the 10.0.0.0/8 RFC1918 IP address space
+## 06. Reject the 172.16.0.0/12 RFC1918 IP address space
+## 07. Reject the 192.168.0.0./16 RFC1918 IP address space
+## 08. Reject the AWS metadata service
+## 09. Accept connections where:
+## --- Container_ip_one equals DESTINATION IP
+## 10. Accept connections where:
+## --- Container_ip_one equals SOURCE IP
+## 11. Accept connections where:
+## --- Container_ip_two equals DESTINATION IP
+## 12. Accept connections where:
+## --- Container_ip_two equals SOURCE IP
+## 13. Accept ALL UDP DNS Traffic
+## 14. Save iptables rules
+##
+files:
+  "/root/firewall.sh" :
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      container_ip_one='172.17.0.2'
+      container_ip_two='172.17.0.3'
+      iptables --flush DOCKER-USER
+      iptables --insert DOCKER-USER --jump REJECT
+      iptables --insert DOCKER-USER --destination 10.0.0.0/8 --jump REJECT
+      iptables --insert DOCKER-USER --destination 172.16.0.0/12 --jump REJECT
+      iptables --insert DOCKER-USER --destination 192.168.0.0/16 --jump REJECT
+      iptables --insert DOCKER-USER --destination 169.254.169.254 --jump REJECT
+      iptables --insert DOCKER-USER --protocol tcp --destination $container_ip_one --jump ACCEPT
+      iptables --insert DOCKER-USER --protocol tcp --source $container_ip_one --jump ACCEPT
+      iptables --insert DOCKER-USER --protocol tcp --destination $container_ip_two --jump ACCEPT
+      iptables --insert DOCKER-USER --protocol tcp --source $container_ip_two --jump ACCEPT
+      iptables --insert DOCKER-USER --protocol udp --destination-port 53 --jump ACCEPT
+      iptables --insert DOCKER-USER --protocol udp --source-port 53 --jump ACCEPT
+      iptables-save > /etc/sysconfig/iptables
+container_commands:
+  firewall:
+    command: "sh /root/firewall.sh"


### PR DESCRIPTION
This branch address the security issue raised by the SubGraph audit. https://github.com/hypothesis/private-issues/issues/56. It is the same code that we have deployed to Via3.

In essence we are using IP Tables to REJECT access from the docker container to RFC1918 IP Address space + The AWS metadata service.