### PR TITLE
EB Definition - h-periodic-prod

### DIFF
--- a/h-periodic/env-prod.yml
+++ b/h-periodic/env-prod.yml
@@ -6,10 +6,9 @@ EnvironmentTier:
   Name: WebServer
 OptionSettings:
   aws:elasticbeanstalk:command:
-    DeploymentPolicy: Immutable
+    DeploymentPolicy: AllAtOnce
   aws:elasticbeanstalk:environment:
-    EnvironmentType: LoadBalanced
-    LoadBalancerType: application
+    EnvironmentType: SingleInstance
     ServiceRole: aws-elasticbeanstalk-service-role
   aws:elasticbeanstalk:environment:process:default:
     HealthCheckPath: /_status
@@ -18,21 +17,12 @@ OptionSettings:
   aws:ec2:vpc:
     Subnets: subnet-66b8413f,subnet-2fdcbe4a
     VPCId: vpc-bc4d91d9
-    ELBSubnets: subnet-66b8413f,subnet-2fdcbe4a
-    ELBScheme: internal
     AssociatePublicIpAddress: true
-  aws:autoscaling:updatepolicy:rollingupdate:
-    RollingUpdateType: Immutable
-    RollingUpdateEnabled: true
-  aws:elbv2:listener:default:
-    ListenerEnabled: True
-    DefaultProcess: default
   aws:autoscaling:launchconfiguration:
     SecurityGroups: sg-fdf9c19a
     IamInstanceProfile: aws-elasticbeanstalk-ec2-role
     InstanceType: t3.micro
     EC2KeyName: ops-20191105
-
   aws:autoscaling:asg:
     MaxSize: '1'
     MinSize: '1'


### PR DESCRIPTION
This update changes the Elastic Beanstalk definition for h-periodic-prod. The loadbalancer has been removed and we are changing to a single instance deployment.

The update has already been tested in QA. Here is a link to some internal discussion: https://hypothes-is.slack.com/archives/CR3E3S7K8/p1607540043027600