### PR TITLE
EB Definition - Move Via3 services to public subnet

### DIFF
--- a/via3/env-prod.yml
+++ b/via3/env-prod.yml
@@ -21,7 +21,7 @@ OptionSettings:
   aws:elasticbeanstalk:healthreporting:system:
     SystemType: enhanced
   aws:ec2:vpc:
-    Subnets: subnet-2fdcbe4a,subnet-66b8413f
+    Subnets: subnet-0f19e456,subnet-ee2c418b
     VPCId: vpc-bc4d91d9
     ELBSubnets: subnet-9bf985c3,subnet-3b21015f
     ELBScheme: public

--- a/via3/env-qa.yml
+++ b/via3/env-qa.yml
@@ -19,7 +19,7 @@ OptionSettings:
   aws:elasticbeanstalk:healthreporting:system:
     SystemType: enhanced
   aws:ec2:vpc:
-    Subnets: subnet-2fdcbe4a,subnet-66b8413f
+    Subnets: subnet-0f19e456,subnet-ee2c418b
     VPCId: vpc-bc4d91d9
     ELBSubnets: subnet-9bf985c3,subnet-3b21015f
     ELBScheme: public


### PR DESCRIPTION
This commit moves the Via3 services to our public subnet. It is a
rollback from commit `149c6f8`.

Due to our Google Drive integration it is not possible for us to run
Via3 in the public subnets. This is because we are presenting a
consistent IP addresses when using the private subnet, and Google limits
the number of requests based on IP address.