### PR TITLE
EB Definition - ViaHTML

### DIFF
--- a/viahtml/env-prod.yml
+++ b/viahtml/env-prod.yml
@@ -43,15 +43,15 @@ OptionSettings:
     InstanceType: t3.small
     EC2KeyName: ops-20191105
   aws:autoscaling:asg:
-    MaxSize: '4'
-    MinSize: '2'
+    MaxSize: '10'
+    MinSize: '4'
   aws:autoscaling:trigger:
     MeasureName: CPUUtilization
     Statistic: Average
     Unit: Percent
     Period: '2'
     EvaluationPeriods: '2'
-    UpperThreshold: '60'
-    UpperBreachScaleIncrement: '1'
-    LowerThreshold: '30'
+    UpperThreshold: '45'
+    UpperBreachScaleIncrement: '2'
+    LowerThreshold: '20'
     LowerBreachScaleIncrement: '-1'


### PR DESCRIPTION
This commit updates the environment definition for ViaHTML. We are moving to:

1. Min hosts online(MinSize): 4
2. Max hosts online(MaxSize): 10
3. CPU Scale out threshold(UpperThreshold): 45%
4. CPU Scale in threshold(LowerThreshold): 20%
5. A BreachDuration of: 4 mins (2x 2 min checks)