### PR TITLE
EB - Update environment definition ViaHTML Prod

### DIFF
--- a/viahtml/env-prod.yml
+++ b/viahtml/env-prod.yml
@@ -40,7 +40,7 @@ OptionSettings:
   aws:autoscaling:launchconfiguration:
     SecurityGroups: sg-fdf9c19a
     IamInstanceProfile: aws-elasticbeanstalk-ec2-role
-    InstanceType: t3.small
+    InstanceType: t3.medium
     EC2KeyName: ops-20191105
   aws:autoscaling:asg:
     MaxSize: '10'


### PR DESCRIPTION
This commit updates the EC2 instance type used to serve the ViaHTML application. Changing from `t3.small` to `t3.medium`.

Information on the reason for the change can be found here: https://github.com/hypothesis/playbook/issues/549