### PR TITLE
EB - Environment definition updates for Via, Via3 and ViaHTML

### DIFF
--- a/via/env-prod.yml
+++ b/via/env-prod.yml
@@ -16,6 +16,16 @@ OptionSettings:
   aws:elasticbeanstalk:environment:process:default:
     HealthCheckPath: /
   aws:elasticbeanstalk:healthreporting:system:
+    ConfigDocument:
+      Rules:
+        Environment:
+          Application:
+            ApplicationRequests4xx:
+              Enabled: false
+          ELB:
+            ELBRequests4xx:
+              Enabled: false
+      Version: 1
     SystemType: enhanced
     HealthCheckSuccessThreshold: Severe
   aws:ec2:vpc:

--- a/via3/env-prod.yml
+++ b/via3/env-prod.yml
@@ -19,6 +19,16 @@ OptionSettings:
   aws:elasticbeanstalk:environment:process:default:
     HealthCheckPath: /_status
   aws:elasticbeanstalk:healthreporting:system:
+    ConfigDocument:
+      Rules:
+        Environment:
+          Application:
+            ApplicationRequests4xx:
+              Enabled: false
+          ELB:
+            ELBRequests4xx:
+              Enabled: false
+      Version: 1
     SystemType: enhanced
   aws:ec2:vpc:
     Subnets: subnet-0f19e456,subnet-ee2c418b

--- a/viahtml/env-prod.yml
+++ b/viahtml/env-prod.yml
@@ -19,6 +19,16 @@ OptionSettings:
   aws:elasticbeanstalk:environment:process:default:
     HealthCheckPath: /_status
   aws:elasticbeanstalk:healthreporting:system:
+    ConfigDocument:
+      Rules:
+        Environment:
+          Application:
+            ApplicationRequests4xx:
+              Enabled: false
+          ELB:
+            ELBRequests4xx:
+              Enabled: false
+      Version: 1
     SystemType: enhanced
   aws:ec2:vpc:
     Subnets: subnet-2fdcbe4a,subnet-66b8413f


### PR DESCRIPTION
This commit brings our code in-line with the live configuration. It updates the environment definitions for the via proxies, and configures the environments to ignore 4xx responses received via the application and ELB. 

The method of defining these features seems a little vague in the documentation. I have made the update based on enhanced health details here: https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/health-enhanced-rules.html

I am not 100% sure if setting the `Enabled:` value to `false` enables or disables the check box as it is seen in the AWS console. So I have made my best guess. We may need need to make another commit if this has the opposite effect.

<img width="782" alt="Screenshot 2021-03-02 at 14 16 00" src="https://user-images.githubusercontent.com/18003117/109661407-dd503f00-7b61-11eb-9f14-2bd3b7f4182b.png">
 