### PR TITLE
NewRelic - Infra Agent Update - Disable process sampling

### DIFF
--- a/common/ebextensions/100_new_relic_infra_agent.config
+++ b/common/ebextensions/100_new_relic_infra_agent.config
@@ -31,6 +31,7 @@ files:
         echo "Creating NewRelic configuration file"
         echo "license_key: $key" > /etc/newrelic-infra.yml
         echo "display_name: $display_name" >> /etc/newrelic-infra.yml
+        echo "enable_process_metrics: false" >> /etc/newrelic-infra.yml
         #
         echo "Configuring infra agent yum repo"
         curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/el/6/x86_64/newrelic-infra.repo


### PR DESCRIPTION
This commit updates the configuration file used by the NewRelic infra agent, and disables the process sampling by setting `enable_process_metrics` to false.

More information on the parameter can be found [here](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings) Search for: `enable_process_metrics`