### PR TITLE
eb-release - update VERSION_LABEL to include environment

### DIFF
--- a/bin/eb-release
+++ b/bin/eb-release
@@ -84,7 +84,7 @@ EB_BUCKET=$(aws elasticbeanstalk create-storage-location --query S3Bucket --outp
 
 status "uploading application version to S3"
 
-VERSION_LABEL="${APP}-$(date -u +"%Y%m%dT%H%M%SZ")-${APP_DOCKER_TAG}"
+VERSION_LABEL="${APP}-${APP_ENV}$(date -u +"%Y%m%dT%H%M%SZ")-${APP_DOCKER_TAG}"
 SRCBUNDLE="${SRCBUNDLEDIR}/bundle.zip"
 
 pushd "$SRCBUNDLEDIR" > /dev/null


### PR DESCRIPTION
Updating the version label outputted by the `eb-release` script so we can handle parallel builds to multiple environments with the same application name.