### PR TITLE
Deployment tooling update - bin/jenkins

### DIFF
--- a/bin/jenkins
+++ b/bin/jenkins
@@ -41,6 +41,10 @@ if [ -z "$REGION" ]; then
     abort "cannot proceed unless \$REGION is specified"
 fi
 
+if [ ! $REGION = 'us-west-1' ]; then
+    APP=$(echo $APP | awk -F- '{print $1}')
+fi
+
 if [ "$TYPE" = "deploy" ]; then
   if [ -z "$APP_DOCKER_VERSION" ]; then
     abort "cannot proceed with deploy unless \$APP_DOCKER_VERSION is specified"


### PR DESCRIPTION
Introduced a conditional statement to remove the hyphen and 2 letter
region code from the value of $APP when not operating in us-west-1.

As an example this is $APP for Canada before the update.
```
APP=h-ca
```