### PR TITLE
EB Definition - Changed the H SSL certificate in Canada

### DIFF
--- a/h/env-prod-ca.yml
+++ b/h/env-prod-ca.yml
@@ -34,7 +34,7 @@ OptionSettings:
   aws:elbv2:listener:443:
     ListenerEnabled: true
     SSLPolicy: ELBSecurityPolicy-TLS-1-2-2017-01
-    SSLCertificateArns: arn:aws:acm:ca-central-1:964867326460:certificate/ea688d09-a53e-406e-8e42-7f3568b029e2
+    SSLCertificateArns: arn:aws:acm:ca-central-1:964867326460:certificate/80638958-ebc8-49ed-acc3-0e16e820b398
     DefaultProcess: default
     Protocol: HTTPS
   aws:autoscaling:launchconfiguration:


### PR DESCRIPTION
This commit updates the Elastic Beanstalk environment definition for H
in Canada. The SSL cert attached to the load balancer has been changed
to the `*.caprod.svc.hypothes.is` wildcard.