### PR TITLE
EB definition - Upgrade h-periodic-ca platform version

### DIFF
--- a/h-periodic/env-prod-ca.yml
+++ b/h-periodic/env-prod-ca.yml
@@ -1,6 +1,6 @@
 AWSConfigurationTemplateVersion: 1.1.0.0
 Platform:
-  PlatformArn: arn:aws:elasticbeanstalk:ca-central-1::platform/Docker running on 64bit Amazon Linux/2.16.8
+  PlatformArn: arn:aws:elasticbeanstalk:ca-central-1::platform/Docker running on 64bit Amazon Linux 2/3.4.1
 EnvironmentTier:
   Type: Standard
   Name: WebServer


### PR DESCRIPTION
The platform version for h-periodic-ca has been upgrade to:
- Docker running on 64bit Amazon Linux 2/3.4.1