### PR TITLE
analytics-dashboard-qa - iamsync ebextension update

### DIFF
--- a/analytics-dashboard/ebextensions/qa/90_iamsync.config
+++ b/analytics-dashboard/ebextensions/qa/90_iamsync.config
@@ -39,3 +39,5 @@ commands:
     command: "python3 -m venv /root/venv"
   04_install-pip-packages:
     command: "source /root/venv/bin/activate ; pip install wheel boto3 pyyaml"
+  05_run_iamsync:
+    command: "/root/venv/bin/python /root/bin/iamsync.py"


### PR DESCRIPTION
The extension will now execute iamsync once installed, which means we
don't have to wait until the cron schedule kicks in.