### PR TITLE
Introduced a delay in starting iamsync ebextension

### DIFF
--- a/analytics-dashboard/ebextensions/qa/02_iamsync.config
+++ b/analytics-dashboard/ebextensions/qa/02_iamsync.config
@@ -39,5 +39,7 @@ commands:
     command: "python3 -m venv /root/venv"
   04_install-pip-packages:
     command: "source /root/venv/bin/activate ; pip install wheel boto3 pyyaml"
-  05_run_iamsync:
+  05_wait_for_papertrail_to_start_logging:
+    command: "sleep 60"
+  06_run_iamsync:
     command: "/root/venv/bin/python /root/bin/iamsync.py"


### PR DESCRIPTION
Papertrail takes a while before it starts streaming logs. This causes a
problem with iamsync because we lose logs for the initial run. To try
and work around this a 60 second pause has been introduced before
running iamsync.