### PR TITLE
elastic beanstalk platform upgrade - lms canada

### DIFF
--- a/lms/env-prod-ca.yml
+++ b/lms/env-prod-ca.yml
@@ -1,6 +1,6 @@
 AWSConfigurationTemplateVersion: 1.1.0.0
 Platform:
-  PlatformArn: arn:aws:elasticbeanstalk:ca-central-1::platform/Docker running on 64bit Amazon Linux/2.16.8
+  PlatformArn: arn:aws:elasticbeanstalk:ca-central-1::platform/Docker running on 64bit Amazon Linux 2/3.4.1
 EnvironmentTier:
   Type: Standard
   Name: WebServer


### PR DESCRIPTION
Platform has been upgrade to:
- Docker running on 64bit Amazon Linux 2/3.4.1