### PR TITLE
h-ca eb definition update

### DIFF
--- a/h/env-prod-ca.yml
+++ b/h/env-prod-ca.yml
@@ -27,7 +27,7 @@ OptionSettings:
     ELBScheme: public
     AssociatePublicIpAddress: true
   aws:autoscaling:updatepolicy:rollingupdate:
-    RollingUpdateType: Immutable
+    RollingUpdateType: Health
     RollingUpdateEnabled: true
   aws:elbv2:listener:default:
     ListenerEnabled: false


### PR DESCRIPTION
I am running into problems syncing the h ca environment due to
conflicting configuration.

- DeploymentPolicy: RollingWithAdditionalBatch
- RollingUpdateType: Immutable

I know changing the 'DeploymentPolicy' to 'Immutable' will allow us to
sync the environment. However, that mode also doubles the deploy time.

I have set 'RollingUpdateType' to 'Health' as a test to see what impact
it has.