### PR TITLE
eb platform upgrade - bouncer-qa

### DIFF
--- a/bouncer/env-qa.yml
+++ b/bouncer/env-qa.yml
@@ -1,6 +1,6 @@
 AWSConfigurationTemplateVersion: 1.1.0.0
 Platform:
-  PlatformArn: arn:aws:elasticbeanstalk:us-west-1::platform/Docker running on 64bit Amazon Linux/2.14.2
+  PlatformArn: arn:aws:elasticbeanstalk:us-west-1::platform/Docker running on 64bit Amazon Linux 2/3.4.1
 EnvironmentTier:
   Type: Standard
   Name: WebServer


### PR DESCRIPTION
PlatformARN upgrade to:
- Docker running on 64bit Amazon Linux 2/3.4.1