### PR TITLE
checkmate-qa - eb environment update

### DIFF
--- a/checkmate/env-qa.yml
+++ b/checkmate/env-qa.yml
@@ -36,9 +36,9 @@ OptionSettings:
     DefaultProcess: default
     Protocol: HTTPS
   aws:elbv2:loadbalancer:
-    SecurityGroups: sg-0fb3e01d26a27a182, sg-03290275a3d5e7e9b
+    SecurityGroups: sg-0fb3e01d26a27a182
   aws:autoscaling:launchconfiguration:
-    SecurityGroups: sg-fdf9c19a
+    SecurityGroups: sg-fdf9c19a, sg-03290275a3d5e7e9b
     IamInstanceProfile: aws-elasticbeanstalk-ec2-role
     InstanceType: t3.small
     EC2KeyName: ops-20191105


### PR DESCRIPTION
This commit delivers an update to the eb definition for checkmate-qa.
The environment is currently refusing to sync with our code. I suspect
that is because of a problem with a security group which has been
updated.