### PR TITLE
Platform upgrade - Checkmate-qa

### DIFF
--- a/checkmate/env-qa.yml
+++ b/checkmate/env-qa.yml
@@ -1,6 +1,6 @@
 AWSConfigurationTemplateVersion: 1.1.0.0
 Platform:
-  PlatformArn: arn:aws:elasticbeanstalk:us-west-1::platform/Docker running on 64bit Amazon Linux/2.14.1
+  PlatformArn: arn:aws:elasticbeanstalk:us-west-1::platform/Docker running on 64bit Amazon Linux 2/3.4.1
 EnvironmentTier:
   Type: Standard
   Name: WebServer


### PR DESCRIPTION
This commit upgrades platform being used by Checkmate QA. The
environment is now running:
- Docker running on 64bit Amazon Linux 2/3.4.1