### PR TITLE
elastic beanstalk environment update - h-qa

### DIFF
--- a/h/env-qa.yml
+++ b/h/env-qa.yml
@@ -11,7 +11,7 @@ OptionSettings:
   aws:elasticbeanstalk:command:
     DeploymentPolicy: Rolling 
   aws:autoscaling:updatepolicy:rollingupdate:
-    RollingUpdateType: Immutable
+    RollingUpdateType: Health
     RollingUpdateEnabled: true
   aws:elasticbeanstalk:environment:
     EnvironmentType: LoadBalanced


### PR DESCRIPTION
This commit changes the `RollingUpdateType` defined in the h-qa
configuration, and sets it to `Health` which is the same as our other qa
environments.