### PR TITLE
h-periodic-qa - eb platform upgrade

### DIFF
--- a/h-periodic/env-qa.yml
+++ b/h-periodic/env-qa.yml
@@ -1,6 +1,6 @@
 AWSConfigurationTemplateVersion: 1.1.0.0
 Platform:
-  PlatformArn: arn:aws:elasticbeanstalk:us-west-1::platform/Docker running on 64bit Amazon Linux/2.14.0
+  PlatformArn: arn:aws:elasticbeanstalk:us-west-1::platform/Docker running on 64bit Amazon Linux 2/3.4.1
 EnvironmentTier:
   Type: Standard
   Name: WebServer


### PR DESCRIPTION
This commit upgrades the eb platform for h-periodic-qa. It is now
running:
- Docker running on 64bit Amazon Linux 2/3.4.1