### PR TITLE
analytics-dashboard-prod - RollingUpdateType change

### DIFF
--- a/analytics-dashboard/env-prod.yml
+++ b/analytics-dashboard/env-prod.yml
@@ -25,7 +25,7 @@ OptionSettings:
     ELBScheme: public
     AssociatePublicIpAddress: true
   aws:autoscaling:updatepolicy:rollingupdate:
-    RollingUpdateType: Immutable
+    RollingUpdateType: Health
     RollingUpdateEnabled: true
   aws:elbv2:listener:default:
     ListenerEnabled: false


### PR DESCRIPTION
The RollingUpdateType has been changed to enable updates that:

1. Change the environment configuration
2. Change the running application version