### PR TITLE
h-periodic-prod - platform upgrade

### DIFF
--- a/h-periodic/env-prod.yml
+++ b/h-periodic/env-prod.yml
@@ -1,6 +1,6 @@
 AWSConfigurationTemplateVersion: 1.1.0.0
 Platform:
-  PlatformArn: arn:aws:elasticbeanstalk:us-west-1::platform/Docker running on 64bit Amazon Linux/2.14.0
+  PlatformArn: arn:aws:elasticbeanstalk:us-west-1::platform/Docker running on 64bit Amazon Linux 2/3.4.1
 EnvironmentTier:
   Type: Standard
   Name: WebServer


### PR DESCRIPTION
This commit upgrades the eb platform to:
- Docker running on 64bit Amazon Linux 2/3.4.1