### PR TITLE
h-prod - platform upgrade

### DIFF
--- a/h/env-prod.yml
+++ b/h/env-prod.yml
@@ -1,6 +1,6 @@
 AWSConfigurationTemplateVersion: 1.1.0.0
 Platform:
-  PlatformArn: arn:aws:elasticbeanstalk:us-west-1::platform/Docker running on 64bit Amazon Linux/2.12.14
+  PlatformArn: arn:aws:elasticbeanstalk:us-west-1::platform/Docker running on 64bit Amazon Linux 2/3.4.1
 EnvironmentTier:
   Type: Standard
   Name: WebServer
@@ -27,7 +27,7 @@ OptionSettings:
     ELBScheme: public
     AssociatePublicIpAddress: true
   aws:autoscaling:updatepolicy:rollingupdate:
-    RollingUpdateType: Immutable
+    RollingUpdateType: Health
     RollingUpdateEnabled: true
   aws:elbv2:listener:default:
     ListenerEnabled: false


### PR DESCRIPTION
This commit upgrades the eb platform to:
1. Docker running on 64bit Amazon Linux 2/3.4.1
2. Sets RollingUpdateType to Health
https://github.com/hypothesis/playbook/issues/698#issuecomment-876187206