### PR TITLE
lms-ca-prod - RollingUpdateType

### DIFF
--- a/lms/env-prod-ca.yml
+++ b/lms/env-prod-ca.yml
@@ -27,7 +27,7 @@ OptionSettings:
     ELBScheme: public
     AssociatePublicIpAddress: true
   aws:autoscaling:updatepolicy:rollingupdate:
-    RollingUpdateType: Immutable
+    RollingUpdateType: Health
     RollingUpdateEnabled: true
   aws:elbv2:listener:default:
     ListenerEnabled: false


### PR DESCRIPTION
This commit sets RollingUpdateType to Health to enable a platform
upgrade to complete.