### PR TITLE
lms-viahtml-prod - platform upgrade

### DIFF
--- a/lms-viahtml/env-prod.yml
+++ b/lms-viahtml/env-prod.yml
@@ -1,6 +1,6 @@
 AWSConfigurationTemplateVersion: 1.1.0.0
 Platform:
-  PlatformArn: arn:aws:elasticbeanstalk:us-west-1::platform/Docker running on 64bit Amazon Linux/2.14.1
+  PlatformArn: arn:aws:elasticbeanstalk:us-west-1::platform/Docker running on 64bit Amazon Linux 2/3.4.1
 EnvironmentTier:
   Type: Standard
   Name: WebServer
@@ -25,7 +25,7 @@ OptionSettings:
     ELBScheme: public
     AssociatePublicIpAddress: true
   aws:autoscaling:updatepolicy:rollingupdate:
-    RollingUpdateType: Immutable
+    RollingUpdateType: Health
     RollingUpdateEnabled: true
   aws:elbv2:listener:default:
     ListenerEnabled: false


### PR DESCRIPTION
This commit upgrades the eb platform to:
1. Docker running on 64bit Amazon Linux 2/3.4.1
2. Sets RollingUpdateType to Health