### PR TITLE
h-qa - update default ec2 nginx config

### DIFF
--- a/h/ebextensions/qa/80_nginx_workers.config
+++ b/h/ebextensions/qa/80_nginx_workers.config
@@ -1,7 +1,6 @@
 # ebextension to deliver a custom nginx configuration.
-# We are introducing 2 changes...
-# 1. Introduce the worker_rlimit_nofile parameter with a value of 1536
-# 2. Increase worker_connections to 1536
+# The is the default nginx.conf as found on a QA instance running on the `t3a.small` instance type.
+# The only change is to the worker_connections which has been increased to 4096
 files:
   "/etc/nginx/nginx.conf" :
     mode: "000644"
@@ -13,14 +12,14 @@ files:
 
       user  nginx;
       worker_processes  auto;
-      worker_rlimit_nofile 1536;
+      worker_rlimit_nofile    65936;
 
       error_log  /var/log/nginx/error.log;
 
       pid        /var/run/nginx.pid;
 
       events {
-          worker_connections  1536;
+          worker_connections  4096;
       }
 
       http {
@@ -29,8 +28,36 @@ files:
 
           access_log    /var/log/nginx/access.log;
 
-          log_format  healthd '$msec"$uri"$status"$request_time"$upstream_response_time"$http_x_forwarded_for';
+          log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                                '$status $body_bytes_sent "$http_referer" '
+                                '"$http_user_agent" "$http_x_forwarded_for"';
 
           include       /etc/nginx/conf.d/*.conf;
-          include       /etc/nginx/sites-enabled/*;
+          
+          map $http_upgrade $connection_upgrade {
+                  default       "upgrade";
+          }
+
+          server {
+              listen 80 default_server;
+              gzip on;
+              gzip_comp_level 4;
+              gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+              access_log    /var/log/nginx/access.log main;
+
+              location / {
+                  proxy_pass            http://docker;
+                  proxy_http_version    1.1;
+                   
+                  proxy_set_header    Connection             $connection_upgrade;
+                  proxy_set_header    Upgrade                $http_upgrade;          
+                  proxy_set_header    Host                   $host;
+                  proxy_set_header    X-Real-IP              $remote_addr;
+                  proxy_set_header    X-Forwarded-For        $proxy_add_x_forwarded_for;
+              }
+    
+              # Include the Elastic Beanstalk generated locations
+              include conf.d/elasticbeanstalk/*.conf;
+          
+         }
       }


### PR DESCRIPTION
This commit delivers an updated nginx.conf for h qa. The
worker_connections has been increased from the default of 1024 to 4096.