### PR TITLE
Updated eb-release to support platform

### DIFF
--- a/bin/eb-release
+++ b/bin/eb-release
@@ -75,6 +75,18 @@ if [ -d "${APP}/ebextensions/${APP_ENV}" ]; then
   cp ${APP}/ebextensions/${APP_ENV}/*.config "$EBEXTENSIONS"
 fi
 
+# Conditionally create platform extension hierarchy. Used to provide
+# custom platform configuration on a per app or global basis.
+PLATFORMEXTENSIONS="${SRCBUNDLEDIR}/.platform"
+if [ -d "common/platform" ]; then
+  mkdir -p "$PLATFORMEXTENSIONS"
+  cp -r common/platform/ "$PLATFORMEXTENSIONS"
+fi
+if [ -d "${APP}/platform/${APP_ENV}" ]; then
+  mkdir -p "$PLATFORMEXTENSIONS"
+  cp -r ${APP}/platform/${APP_ENV}/ "$PLATFORMEXTENSIONS"
+fi
+
 # And clean up when we're done...
 trap 'rm -r "$SRCBUNDLEDIR"' EXIT
 


### PR DESCRIPTION
This commit adds support for elastic beanstalk platform extensions, which are used to provide custom updates of the Linux platform. We need this to perform updates to Linux level configuration.

More information on the functionality can be found in the AWS docs: https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/platforms-linux-extend.html

A slack discussion has been started here: https://hypothes-is.slack.com/archives/CR3E3S7K8/p1626078418105400