### PR TITLE
Override default h-qa nginx.conf

### DIFF
--- a/h/platform/qa/nginx/nginx.conf
+++ b/h/platform/qa/nginx/nginx.conf
@@ -1,5 +1,6 @@
 # Elastic Beanstalk Nginx Configuration File
 # Custom version to increase worker_connections from 1024 to 4096
+# Created by a platform customisation to h-qa
 
 user  nginx;
 worker_processes  auto;


### PR DESCRIPTION
This commit overrides the default nginx.conf for h-qa using the new platform system.

This is the default nginx.conf as it is shipped by Elastic Beanstalk on a t3a.small ec2 instance with a single override to the `worker_connections` setting. 

Originally set to `1024`, this config increases the limit to `4096`