### PR TITLE
eb-release fixed syntax with cp command

### DIFF
--- a/bin/eb-release
+++ b/bin/eb-release
@@ -80,11 +80,11 @@ fi
 PLATFORMEXTENSIONS="${SRCBUNDLEDIR}/.platform"
 if [ -d "common/platform" ]; then
   mkdir -p "$PLATFORMEXTENSIONS"
-  cp -r common/platform/ "$PLATFORMEXTENSIONS"
+  cp -r common/platform/* "$PLATFORMEXTENSIONS"
 fi
 if [ -d "${APP}/platform/${APP_ENV}" ]; then
   mkdir -p "$PLATFORMEXTENSIONS"
-  cp -r ${APP}/platform/${APP_ENV}/ "$PLATFORMEXTENSIONS"
+  cp -r ${APP}/platform/${APP_ENV}/* "$PLATFORMEXTENSIONS"
 fi
 
 # And clean up when we're done...


### PR DESCRIPTION
The recent update to eb-release to support platform extensions
introduced a problem with the cp command that cause an additional
directory to be added to the application source bundle.