### PR TITLE
h-prod ec2 nginx.conf override

### DIFF
--- a/h/platform/prod/nginx/nginx.conf
+++ b/h/platform/prod/nginx/nginx.conf
@@ -1,0 +1,54 @@
+# Elastic Beanstalk Nginx Configuration File
+# Custom version to increase worker_connections from 1024 to 4096
+# Created by a platform customisation to h-prod
+
+user  nginx;
+worker_processes  auto;
+error_log  /var/log/nginx/error.log;
+pid        /var/run/nginx.pid;
+worker_rlimit_nofile    200000;
+
+events {
+    worker_connections  4096;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    access_log    /var/log/nginx/access.log;
+
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                          '$status $body_bytes_sent "$http_referer" '
+                          '"$http_user_agent" "$http_x_forwarded_for"';
+
+    include  conf.d/*.conf;
+
+    map $http_upgrade $connection_upgrade {
+            default       "upgrade";
+    }
+
+    server {
+        listen 80 default_server;
+        gzip on;
+        gzip_comp_level 4;
+        gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+        access_log    /var/log/nginx/access.log main;
+
+        location / {
+            proxy_pass            http://docker;
+            proxy_http_version    1.1;
+
+            proxy_set_header    Connection             $connection_upgrade;
+            proxy_set_header    Upgrade                $http_upgrade;
+            proxy_set_header    Host                   $host;
+            proxy_set_header    X-Real-IP              $remote_addr;
+            proxy_set_header    X-Forwarded-For        $proxy_add_x_forwarded_for;
+        }
+
+        # Include the Elastic Beanstalk generated locations
+        include conf.d/elasticbeanstalk/*.conf;
+    }
+}


### PR DESCRIPTION
This commit delivers a custom ec2 nginx.conf for h-prod. The worker_connections settings has been increased from 1024 to 4096.

Link to slack conversation: https://hypothes-is.slack.com/archives/CR3E3S7K8/p1626089024109500?thread_ts=1626078418.105400&cid=CR3E3S7K8