### PR TITLE
via-prod - install extensions

### DIFF
--- a/via/ebextensions/prod/01_papertrail.config
+++ b/via/ebextensions/prod/01_papertrail.config
@@ -20,6 +20,7 @@ files:
       files:
         - /var/log/eb-docker/containers/eb-current-app/*.log
         - /var/log/nginx/*.log
+        - /var/log/iamsync.log
       hostname: ##DO_NOT_MODIFY-SETUP_WILL_REPLACE_THIS##
       destination:
         host: logs.papertrailapp.com

--- a/via/ebextensions/prod/02_iamsync.config
+++ b/via/ebextensions/prod/02_iamsync.config
@@ -1,0 +1,35 @@
+# Configure Elastic Beanstalk EC2 hosts to use iamsync SSH
+# https://github.com/hypothesis/iamsync
+files:
+  "/etc/iamsync.yml":
+    mode: "000600"
+    owner: root
+    group: root
+    content: |
+      iamsync:
+        - iam_group: engineering
+          sudo_rule: "ALL=(ALL) NOPASSWD:ALL"
+          local_gid: 1025
+
+
+  "/etc/cron.d/iamsync":
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      SHELL=/bin/bash
+      PATH="venv/bin:/usr/sbin:/bin"
+      5,35 * * * * root sleep ${RANDOM: -1} ; python bin/iamsync.py
+
+
+commands:
+  01_create-bin-dir:
+    command: "mkdir -p /root/bin"
+  02_download-iamsync:
+    command: "curl https://raw.githubusercontent.com/hypothesis/iamsync/main/iamsync.py -o /root/bin/iamsync.py"
+  03_create-python-venv:
+    command: "python3 -m venv /root/venv"
+  04_install-pip-packages:
+    command: "source /root/venv/bin/activate ; pip install wheel boto3 pyyaml"
+  05_run_iamsync:
+    command: "/root/venv/bin/python /root/bin/iamsync.py"

--- a/via/platform/prod/nginx/conf.d/proxy_buffers.conf
+++ b/via/platform/prod/nginx/conf.d/proxy_buffers.conf
@@ -1,0 +1,6 @@
+# These settings override the NGINX defaults, and enable Via to handle
+# large headers that the likes of twitter and youtube send back.
+# Delivered using a via-prod platform extension.
+proxy_buffer_size          128k;
+proxy_buffers              4 256k;
+proxy_busy_buffers_size    256k;

--- a/via/platform/qa/nginx/conf.d/proxy_buffers.conf
+++ b/via/platform/qa/nginx/conf.d/proxy_buffers.conf
@@ -1,0 +1,6 @@
+# These settings override the NGINX defaults, and enable Via to handle
+# large headers that the likes of twitter and youtube send back.
+# Delivered using a via-qa platform extension.
+proxy_buffer_size          128k;
+proxy_buffers              4 256k;
+proxy_busy_buffers_size    256k;


### PR DESCRIPTION
This commit installs the iamsync ssh extension, and modifies the
papertrail config to include the iamsync.log file.

In addition, nginx customisations previously installed using
ebextensions have been migrated to platform extensions.