### PR TITLE
analytics-dashboard-qa - docker nofile extension

### DIFF
--- a/analytics-dashboard/Dockerrun.aws.json
+++ b/analytics-dashboard/Dockerrun.aws.json
@@ -7,12 +7,5 @@
     {
       "ContainerPort": "8000"
     }
-  ],
-  "ulimits": [
-    {
-      "name": "nofile",
-      "softLimit": 4096,
-      "hardLimit": 4096
-    }
   ]
 }

--- a/analytics-dashboard/ebextensions/qa/03_docker_nofile.config
+++ b/analytics-dashboard/ebextensions/qa/03_docker_nofile.config
@@ -1,0 +1,28 @@
+# Increase nofile ulimit on elastic beanstalk ec2 docker daemon.
+#
+files:
+  "/etc/sysconfig/docker":
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      # This is the default /etc/sysconfig/docker file shipped with 
+      # Docker running on 64bit Amazon Linux 2/3.4.1.
+      #
+      # A small change has been made to raise the nofile softlimit
+      # imposed by the Docker daemon. Originally set to 1024. This config
+      # raises that value to 4096.
+      #
+      # The max number of open files for the daemon itself, and all
+      # running containers.  The default value of 1048576 mirrors the value
+      # used by the systemd service unit.
+      DAEMON_MAXFILES=1048576
+      
+      # Additional startup options for the Docker daemon, for example:
+      # OPTIONS="--ip-forward=true --iptables=true"
+      # By default we limit the number of open files per container
+      OPTIONS="--default-ulimit nofile=4096:4096"
+
+      # How many seconds the sysvinit script waits for the pidfile to appear
+      # when starting the daemon.
+      DAEMON_PIDFILE_TIMEOUT=10


### PR DESCRIPTION
This commit delivers a ebextension to increase the nofile softlimit
imposed by the Docker daemon. The original value was set to 1024, and
the extension raises that limit to 4096 to match the hardlimit.

In addition, updates made to the Dockerrun.aws.json file have been
removed. EB does not seem to support this method of customisation.