### PR TITLE
analytics-dashboard-qa - updated docker nofile extension

### DIFF
--- a/analytics-dashboard/ebextensions/qa/03_docker_nofile.config
+++ b/analytics-dashboard/ebextensions/qa/03_docker_nofile.config
@@ -26,3 +26,7 @@ files:
       # How many seconds the sysvinit script waits for the pidfile to appear
       # when starting the daemon.
       DAEMON_PIDFILE_TIMEOUT=10
+
+container_commands:
+  01_docker_restart:
+    command: "systemctl restart docker"


### PR DESCRIPTION
This commit updates the docker nofile extension, and adds a
container_command to restart the docker service.