### PR TITLE
Common platform extension update

### DIFF
--- a/common/platform/hooks/prebuild/01_newrelic_setup.sh
+++ b/common/platform/hooks/prebuild/01_newrelic_setup.sh
@@ -7,8 +7,8 @@
 #
 set -eu
 
-key=$(/opt/elasticbeanstalk/bin/get-config environment -k NEW_RELIC_LICENSE_KEY)
-display_name=$(/opt/elasticbeanstalk/bin/get-config environment -k NEW_RELIC_APP_NAME)
+key=$(/opt/elasticbeanstalk/bin/get-config environment -k NEW_RELIC_LICENSE_KEY || true)
+display_name=$(/opt/elasticbeanstalk/bin/get-config environment -k NEW_RELIC_APP_NAME || true)
 
 function create_config() {
 cat << CONFIG > /etc/newrelic-infra.yml

--- a/common/platform/hooks/prebuild/02_via_firewall.sh
+++ b/common/platform/hooks/prebuild/02_via_firewall.sh
@@ -18,7 +18,7 @@
 set -eu
 
 # Grab the environment_name value
-ENV_NAME="$(/opt/elasticbeanstalk/bin/get-config container -k environment_name)"
+ENV_NAME="$(/opt/elasticbeanstalk/bin/get-config container -k environment_name || true)"
 # Spilt on '-' and extract the second to last record
 APP="$(echo $ENV_NAME | awk -F- '{print $(NF-1)}')"
 


### PR DESCRIPTION
The following platform extensions have been updated so they don't throw
errors in a situation where environment variables have not been set.
- prebuild/01_newrelic_setup.sh
- prebuild/02_via_firewall.sh